### PR TITLE
D8CORE-938: Change 2&3-col layout to collapse at lg instead of md.

### DIFF
--- a/templates/layouts/three-column.html.twig
+++ b/templates/layouts/three-column.html.twig
@@ -1,14 +1,14 @@
 {% set main_class = '' %}
 {% if content.left|render and content.right|render %}
-  {% set main_class = 'flex-md-6-of-12' %}
+  {% set main_class = 'flex-lg-6-of-12' %}
 {% elseif content.left|render or content.right|render %}
-  {% set main_class = 'flex-md-9-of-12' %}
+  {% set main_class = 'flex-lg-9-of-12' %}
 {% endif %}
 
 <div{{ attributes.addClass('jumpstart-ui--two-column', 'flex-container', settings.centered, settings.extra_classes) }}>
 
   {% if content.left|render %}
-    <aside {{ region_attributes.left.addClass('left-region', 'flex-md-3-of-12') }}>
+    <aside {{ region_attributes.left.addClass('left-region', 'flex-lg-3-of-12') }}>
       {{ content.left }}
     </aside>
   {% endif %}
@@ -20,7 +20,7 @@
   {% endif %}
 
   {% if content.right|render %}
-    <aside {{ region_attributes.right.addClass('right-region', 'flex-md-3-of-12') }}>
+    <aside {{ region_attributes.right.addClass('right-region', 'flex-lg-3-of-12') }}>
       {{ content.right }}
     </aside>
   {% endif %}

--- a/templates/layouts/two-column.html.twig
+++ b/templates/layouts/two-column.html.twig
@@ -1,13 +1,13 @@
 <div{{ attributes.addClass('jumpstart-ui--three-column', 'flex-container', settings.centered, settings.extra_classes) }}>
 
   {% if content.left|render %}
-    <aside {{ region_attributes.left.addClass('left-region', 'flex-md-3-of-12') }}>
+    <aside {{ region_attributes.left.addClass('left-region', 'flex-lg-3-of-12') }}>
       {{ content.left }}
     </aside>
   {% endif %}
 
   {% if content.main|render %}
-    <section {{ region_attributes.main.addClass('main-region', content.left|render  ? 'flex-md-9-of-12' : '') }}>
+    <section {{ region_attributes.main.addClass('main-region', content.left|render  ? 'flex-lg-9-of-12' : '') }}>
       {{ content.main }}
     </section>
   {% endif %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changes breakpoint of the collapse of the layout to match when the primary navigation collapses to the hamburger menu.

# Review By (Date)
- End of the week if possible please.

# Urgency
- Low.

# Steps to Test

1. Review code
2. Think about this choice
3. Post an appropriate gif

# Affected Projects or Products
- Everything using jumpstart_ui

# Associated Issues and/or People
- D8CORE-938 and other linked tickets

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
