### PR TITLE
D8CORE-714: Ensure no duplicate attributes on components.

### DIFF
--- a/templates/components/alert/alert.html.twig
+++ b/templates/components/alert/alert.html.twig
@@ -1,5 +1,8 @@
 {# Override of Decanter's Core Template #}
 {% set attributes = attributes.removeClass('su-alert') %}
+{% if modifier_class is not empty %}
+  {% set attributes = attributes.addClass(modifier_class) %}
+{% endif %}
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 {% extends '@decanter/components/alert/alert.twig' %}

--- a/templates/components/alert/alert.html.twig
+++ b/templates/components/alert/alert.html.twig
@@ -1,0 +1,5 @@
+{# Override of Decanter's Core Template #}
+{% set attributes = attributes.removeClass('su-alert') %}
+{% set modifier_class = attributes.class %}
+{% set attributes = attributes|without('class') %}
+{% extends '@decanter/components/alert/alert.twig' %}

--- a/templates/components/alert/alert.ui_patterns.yml
+++ b/templates/components/alert/alert.ui_patterns.yml
@@ -32,7 +32,7 @@ alert:
       label: Content
       description: "The body of the alert message."
       preview: "This message was brought to you by the good people at Stanford Web Services."
-  use: "@decanter/components/alert/alert.twig"
+  use: "@jumpstart_ui/components/alert/alert.html.twig"
   libraries:
     - alert:
        css:

--- a/templates/components/brand-bar/brand-bar.html.twig
+++ b/templates/components/brand-bar/brand-bar.html.twig
@@ -1,0 +1,5 @@
+{# Glue code for Decanter's component #}
+{% set attributes = attributes.removeClass('su-brand-bar') %}
+{% set modifier_class = attributes.class %}
+{% set attributes = attributes|without('class') %}
+{% extends '@decanter/components/brand-bar/brand-bar.twig' %}

--- a/templates/components/brand-bar/brand-bar.html.twig
+++ b/templates/components/brand-bar/brand-bar.html.twig
@@ -1,5 +1,8 @@
 {# Glue code for Decanter's component #}
 {% set attributes = attributes.removeClass('su-brand-bar') %}
+{% if modifier_class is not empty %}
+  {% set attributes = attributes.addClass(modifier_class) %}
+{% endif %}
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 {% extends '@decanter/components/brand-bar/brand-bar.twig' %}

--- a/templates/components/brand-bar/brand-bar.ui_patterns.yml
+++ b/templates/components/brand-bar/brand-bar.ui_patterns.yml
@@ -17,7 +17,7 @@ brandbar:
       label: White
       description: "Cardinal red wordmark on white background"
       modifier_class: su-brand-bar--white
-  use: "@decanter/components/brand-bar/brand-bar.twig"
+  use: "@jumpstart_ui/components/brand-bar/brand-bar.html.twig"
   libraries:
     - brandbar:
        css:

--- a/templates/components/button/button.html.twig
+++ b/templates/components/button/button.html.twig
@@ -1,0 +1,5 @@
+{# Glue code for Decanter's component #}
+{% set attributes = attributes.removeClass('su-button') %}
+{% set modifier_class = attributes.class %}
+{% set attributes = attributes|without('class', 'value', 'name', 'type') %}
+{% extends '@decanter/components/button/button.twig' %}

--- a/templates/components/button/button.html.twig
+++ b/templates/components/button/button.html.twig
@@ -1,5 +1,8 @@
 {# Glue code for Decanter's component #}
 {% set attributes = attributes.removeClass('su-button') %}
+{% if modifier_class is not empty %}
+  {% set attributes = attributes.addClass(modifier_class) %}
+{% endif %}
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class', 'value', 'name', 'type') %}
 {% extends '@decanter/components/button/button.twig' %}

--- a/templates/components/button/button.ui_patterns.yml
+++ b/templates/components/button/button.ui_patterns.yml
@@ -37,7 +37,7 @@ button:
       label: "Button Type"
       description: "The button type. Eg: submit | button | reset."
       preview: "submit."
-  use: "@decanter/components/button/button.twig"
+  use: "@jumpstart_ui/components/button/button.html.twig"
   libraries:
     - button:
        css:

--- a/templates/components/card/card.html.twig
+++ b/templates/components/card/card.html.twig
@@ -15,4 +15,8 @@
   {{ card_media_custom }}
 {% endblock %}
 
+{% set attributes = attributes.removeClass('su-card') %}
+{% set modifier_class = attributes.class %}
+{% set attributes = attributes|without('class') %}
+
 {% extends "@decanter/components/card/card.twig" %}

--- a/templates/components/card/card.html.twig
+++ b/templates/components/card/card.html.twig
@@ -16,6 +16,9 @@
 {% endblock %}
 
 {% set attributes = attributes.removeClass('su-card') %}
+{% if modifier_class is not empty %}
+  {% set attributes = attributes.addClass(modifier_class) %}
+{% endif %}
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 

--- a/templates/components/cta/cta.html.twig
+++ b/templates/components/cta/cta.html.twig
@@ -1,5 +1,8 @@
 {# Glue code for Decanter's component #}
 {% set attributes = attributes.removeClass('su-cta') %}
+{% if modifier_class is not empty %}
+  {% set attributes = attributes.addClass(modifier_class) %}
+{% endif %}
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class', 'href') %}
 {% extends "@decanter/components/cta/cta.twig" %}

--- a/templates/components/cta/cta.html.twig
+++ b/templates/components/cta/cta.html.twig
@@ -1,0 +1,5 @@
+{# Glue code for Decanter's component #}
+{% set attributes = attributes.removeClass('su-cta') %}
+{% set modifier_class = attributes.class %}
+{% set attributes = attributes|without('class', 'href') %}
+{% extends "@decanter/components/cta/cta.twig" %}

--- a/templates/components/cta/cta.ui_patterns.yml
+++ b/templates/components/cta/cta.ui_patterns.yml
@@ -48,7 +48,7 @@ cta:
       label: "Icon alt text"
       description: "The alt text html property"
       preview: "This is the icon alt text field"
-  use: "@jumpstartui/components/cta/cta.html.twig"
+  use: "@jumpstart_ui/components/cta/cta.html.twig"
   libraries:
     - cta:
        css:

--- a/templates/components/cta/cta.ui_patterns.yml
+++ b/templates/components/cta/cta.ui_patterns.yml
@@ -48,7 +48,7 @@ cta:
       label: "Icon alt text"
       description: "The alt text html property"
       preview: "This is the icon alt text field"
-  use: "@decanter/components/cta/cta.twig"
+  use: "@jumpstartui/components/cta/cta.html.twig"
   libraries:
     - cta:
        css:

--- a/templates/components/date-stacked/date-stacked.html.twig
+++ b/templates/components/date-stacked/date-stacked.html.twig
@@ -1,0 +1,5 @@
+{# Glue code for Decanter's component #}
+{% set attributes = attributes.removeClass('su-date-stacked') %}
+{% set modifier_class = attributes.class %}
+{% set attributes = attributes|without('class') %}
+{% extends "@decanter/components/date-stacked/date-stacked.twig" %}

--- a/templates/components/date-stacked/date-stacked.html.twig
+++ b/templates/components/date-stacked/date-stacked.html.twig
@@ -1,5 +1,8 @@
 {# Glue code for Decanter's component #}
 {% set attributes = attributes.removeClass('su-date-stacked') %}
+{% if modifier_class is not empty %}
+  {% set attributes = attributes.addClass(modifier_class) %}
+{% endif %}
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 {% extends "@decanter/components/date-stacked/date-stacked.twig" %}

--- a/templates/components/date-stacked/date-stacked.ui_patterns.yml
+++ b/templates/components/date-stacked/date-stacked.ui_patterns.yml
@@ -20,7 +20,7 @@ date-stacked:
       label: "Day of month"
       description: "eg: 31"
       preview: "31"
-  use: "@decanter/components/date-stacked/date-stacked.twig"
+  use: "@jumpstart_ui/components/date-stacked/date-stacked.html.twig"
   libraries:
     - date-stacked:
        css:

--- a/templates/components/global-footer/global-footer.html.twig
+++ b/templates/components/global-footer/global-footer.html.twig
@@ -1,5 +1,8 @@
 {# Glue code for Decanter's component #}
 {% set attributes = attributes.removeClass('su-global-footer') %}
+{% if modifier_class is not empty %}
+  {% set attributes = attributes.addClass(modifier_class) %}
+{% endif %}
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 {% extends "@decanter/components/global-footer/global-footer.twig" %}

--- a/templates/components/global-footer/global-footer.html.twig
+++ b/templates/components/global-footer/global-footer.html.twig
@@ -1,0 +1,5 @@
+{# Glue code for Decanter's component #}
+{% set attributes = attributes.removeClass('su-global-footer') %}
+{% set modifier_class = attributes.class %}
+{% set attributes = attributes|without('class') %}
+{% extends "@decanter/components/global-footer/global-footer.twig" %}

--- a/templates/components/global-footer/global-footer.ui_patterns.yml
+++ b/templates/components/global-footer/global-footer.ui_patterns.yml
@@ -1,7 +1,7 @@
 globalfooter:
   label: "Global Footer"
   description: "Global footer element as specified by the Identity Guidelines."
-  use: "@decanter/components/global-footer/global-footer.twig"
+  use: "@jumpstart_ui/components/global-footer/global-footer.html.twig"
   libraries:
     - globalfooter:
        css:

--- a/templates/components/hero/hero.html.twig
+++ b/templates/components/hero/hero.html.twig
@@ -47,9 +47,11 @@
 #}
 {%- set template_path_card = "@jumpstart_ui/components/card/card.html.twig" -%}
 
+{% set attributes = attributes.removeClass('su-hero') %}
+{% set modifier_class = attributes.class %}
+{% set attributes = attributes|without('class') %}
+
 {#
   Include the template.
 #}
-{%
-  include "@decanter/components/hero/hero.twig"
-%}
+{% extends "@decanter/components/hero/hero.twig" %}

--- a/templates/components/hero/hero.html.twig
+++ b/templates/components/hero/hero.html.twig
@@ -48,6 +48,9 @@
 {%- set template_path_card = "@jumpstart_ui/components/card/card.html.twig" -%}
 
 {% set attributes = attributes.removeClass('su-hero') %}
+{% if modifier_class is not empty %}
+  {% set attributes = attributes.addClass(modifier_class) %}
+{% endif %}
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 

--- a/templates/components/link/link.html.twig
+++ b/templates/components/link/link.html.twig
@@ -1,0 +1,5 @@
+{# Glue code for Decanter's component #}
+{% set attributes = attributes.removeClass('su-link') %}
+{% set modifier_class = attributes.class %}
+{% set attributes = attributes|without('class', 'href') %}
+{% extends '@decanter/components/link/link.twig' %}

--- a/templates/components/link/link.html.twig
+++ b/templates/components/link/link.html.twig
@@ -1,5 +1,8 @@
 {# Glue code for Decanter's component #}
 {% set attributes = attributes.removeClass('su-link') %}
+{% if modifier_class is not empty %}
+  {% set attributes = attributes.addClass(modifier_class) %}
+{% endif %}
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class', 'href') %}
 {% extends '@decanter/components/link/link.twig' %}

--- a/templates/components/local-footer/local-footer.html.twig
+++ b/templates/components/local-footer/local-footer.html.twig
@@ -18,6 +18,9 @@
 {%- set secondary_links_header = secondary_links_header|render|striptags('<drupal-render-placeholder><a>')|trim -%}
 
 {% set attributes = attributes.removeClass('su-local-footer') %}
+{% if modifier_class is not empty %}
+  {% set attributes = attributes.addClass(modifier_class) %}
+{% endif %}
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 

--- a/templates/components/local-footer/local-footer.html.twig
+++ b/templates/components/local-footer/local-footer.html.twig
@@ -1,4 +1,4 @@
-{%- extends "@decanter/components/local-footer/local-footer.twig" -%}
+{# Glue code for Decanter's component #}
 {% import "@jumpstart_ui/macros/field-links-to-list.twig" as linklist %}
 {% import "@jumpstart_ui/macros/field-links-to-social-list.twig" as sociallist %}
 
@@ -14,3 +14,10 @@
 {%- set social_links = sociallist.create_list(social_links) -%}
 {%- set primary_links = linklist.create_list(primary_links) -%}
 {%- set secondary_links = linklist.create_list(secondary_links) -%}
+
+
+{% set attributes = attributes.removeClass('su-local-footer') %}
+{% set modifier_class = attributes.class %}
+{% set attributes = attributes|without('class') %}
+
+{%- extends "@decanter/components/local-footer/local-footer.twig" -%}

--- a/templates/components/local-footer/local-footer.html.twig
+++ b/templates/components/local-footer/local-footer.html.twig
@@ -14,7 +14,8 @@
 {%- set social_links = sociallist.create_list(social_links) -%}
 {%- set primary_links = linklist.create_list(primary_links) -%}
 {%- set secondary_links = linklist.create_list(secondary_links) -%}
-
+{%- set primary_links_header = primary_links_header|render|striptags('<drupal-render-placeholder><a>')|trim -%}
+{%- set secondary_links_header = secondary_links_header|render|striptags('<drupal-render-placeholder><a>')|trim -%}
 
 {% set attributes = attributes.removeClass('su-local-footer') %}
 {% set modifier_class = attributes.class %}

--- a/templates/components/lockup/lockup.html.twig
+++ b/templates/components/lockup/lockup.html.twig
@@ -1,5 +1,8 @@
 {# Glue code for Decanter's component #}
 {% set attributes = attributes.removeClass('su-lockup') %}
+{% if modifier_class is not empty %}
+  {% set attributes = attributes.addClass(modifier_class) %}
+{% endif %}
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 {% extends '@decanter/components/lockup/lockup.twig' %}

--- a/templates/components/lockup/lockup.html.twig
+++ b/templates/components/lockup/lockup.html.twig
@@ -1,0 +1,5 @@
+{# Glue code for Decanter's component #}
+{% set attributes = attributes.removeClass('su-lockup') %}
+{% set modifier_class = attributes.class %}
+{% set attributes = attributes|without('class') %}
+{% extends '@decanter/components/lockup/lockup.twig' %}

--- a/templates/components/lockup/lockup.ui_patterns.yml
+++ b/templates/components/lockup/lockup.ui_patterns.yml
@@ -113,7 +113,7 @@ lockup:
       label: "Line 5"
       description: "Line 5 of the unit/site name text (at the bottom part of the lockup)."
       preview: "Line 5 of the unit/site name text "
-  use: "@decanter/components/lockup/lockup.twig"
+  use: "@jumpstart_ui/components/lockup/lockup.html.twig"
   libraries:
     - lockup:
        css:

--- a/templates/components/logo/logo.html.twig
+++ b/templates/components/logo/logo.html.twig
@@ -1,5 +1,8 @@
 {# Glue code for Decanter's component #}
 {% set attributes = attributes.removeClass('su-logo') %}
+{% if modifier_class is not empty %}
+  {% set attributes = attributes.addClass(modifier_class) %}
+{% endif %}
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class', 'href') %}
 {% extends '@decanter/components/logo/logo.twig' %}

--- a/templates/components/logo/logo.html.twig
+++ b/templates/components/logo/logo.html.twig
@@ -1,0 +1,5 @@
+{# Glue code for Decanter's component #}
+{% set attributes = attributes.removeClass('su-logo') %}
+{% set modifier_class = attributes.class %}
+{% set attributes = attributes|without('class', 'href') %}
+{% extends '@decanter/components/logo/logo.twig' %}

--- a/templates/components/logo/logo.ui_patterns.yml
+++ b/templates/components/logo/logo.ui_patterns.yml
@@ -12,7 +12,7 @@ logo:
       label: "Logo Text"
       description: "The text for the ligature logo - either Stanford<br>University or Stanford."
       preview: "Stanford</br>University"
-  use: "@decanter/components/logo/logo.twig"
+  use: "@jumpstart_ui/components/logo/logo.html.twig"
   libraries:
     - logo:
        css:

--- a/templates/components/media/media.html.twig
+++ b/templates/components/media/media.html.twig
@@ -1,2 +1,6 @@
 {%- set media_link = media_link|render|striptags('<drupal-render-placeholder>') -%}
+{% set attributes = attributes.removeClass('su-media') %}
+{% set modifier_class = attributes.class %}
+{% set attributes = attributes|without('class') %}
+
 {% extends "@decanter/components/media/media.twig" %}

--- a/templates/components/media/media.html.twig
+++ b/templates/components/media/media.html.twig
@@ -1,5 +1,8 @@
 {%- set media_link = media_link|render|striptags('<drupal-render-placeholder>') -%}
 {% set attributes = attributes.removeClass('su-media') %}
+{% if modifier_class is not empty %}
+  {% set attributes = attributes.addClass(modifier_class) %}
+{% endif %}
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 

--- a/templates/components/quote/quote.html.twig
+++ b/templates/components/quote/quote.html.twig
@@ -2,4 +2,4 @@
 {% set attributes = attributes.removeClass('su-quote') %}
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
-{% extends '@decanter/components/quote/quote.html.twig' %}
+{% extends '@decanter/components/quote/quote.twig' %}

--- a/templates/components/quote/quote.html.twig
+++ b/templates/components/quote/quote.html.twig
@@ -1,0 +1,5 @@
+{# Glue code for Decanter's component #}
+{% set attributes = attributes.removeClass('su-quote') %}
+{% set modifier_class = attributes.class %}
+{% set attributes = attributes|without('class') %}
+{% extends '@decanter/components/quote/quote.html.twig' %}

--- a/templates/components/quote/quote.html.twig
+++ b/templates/components/quote/quote.html.twig
@@ -1,5 +1,8 @@
 {# Glue code for Decanter's component #}
 {% set attributes = attributes.removeClass('su-quote') %}
+{% if modifier_class is not empty %}
+  {% set attributes = attributes.addClass(modifier_class) %}
+{% endif %}
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 {% extends '@decanter/components/quote/quote.twig' %}

--- a/templates/components/quote/quote.ui_patterns.yml
+++ b/templates/components/quote/quote.ui_patterns.yml
@@ -27,7 +27,7 @@ quote:
       label: "Image alt text"
       description: "The alt text html property"
       preview: "This is the image alt text field"
-  use: "@decanter/components/quote/quote.twig"
+  use: "@jumpstart_ui/components/quote/quote.html.twig"
   libraries:
     - quote:
        css:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removes extra attributes brought through to Decanter templates from the `{{ attributes }}` variable in twig templates.

# Review By (Date)
- Thursday, Jan 30th

# Urgency
- Med/High - Accessibility issues and style issues.

# Steps to Test

1. Check out this branch
2. Build a fresh install of stanford_profile
3. Navigate to, and validate markup for, the home page and an interior page with several paragraphs on them. There should be no duplicate class attribute on the outer wrapper for each component. 
4. Navigate to `/patterns` and validate the markup for each pattern

# Affected Projects or Products
- All things D8

# Associated Issues and/or People
- D8CORE-714
- D8CORE-929
- @katrialesser FYI only.
- @jenbreese If you have a local environment running have a look otherwise FYI only.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)