### PR TITLE
D8CORE-1250: Changed aside and section tags to divs

### DIFF
--- a/templates/layouts/one-column.html.twig
+++ b/templates/layouts/one-column.html.twig
@@ -1,5 +1,5 @@
 <div{{ attributes.addClass('jumpstart-ui--one-column', settings.centered, settings.extra_classes) }}>
-    <section {{ region_attributes.main.addClass('main-region') }}>
+    <div {{ region_attributes.main.addClass('main-region') }}>
       {{ content.main }}
-    </section>
+    </div>
 </div>

--- a/templates/layouts/three-column.html.twig
+++ b/templates/layouts/three-column.html.twig
@@ -8,20 +8,20 @@
 <div{{ attributes.addClass('jumpstart-ui--two-column', 'flex-container', settings.centered, settings.extra_classes) }}>
 
   {% if content.left|render %}
-    <aside {{ region_attributes.left.addClass('left-region', 'flex-lg-3-of-12') }}>
+    <div {{ region_attributes.left.addClass('left-region', 'flex-lg-3-of-12') }}>
       {{ content.left }}
-    </aside>
+    </div>
   {% endif %}
 
   {% if content.main|render %}
-    <section {{ region_attributes.main.addClass('main-region', main_class) }}>
+    <div {{ region_attributes.main.addClass('main-region', main_class) }}>
       {{ content.main }}
-    </section>
+    </div>
   {% endif %}
 
   {% if content.right|render %}
-    <aside {{ region_attributes.right.addClass('right-region', 'flex-lg-3-of-12') }}>
+    <div {{ region_attributes.right.addClass('right-region', 'flex-lg-3-of-12') }}>
       {{ content.right }}
-    </aside>
+    </div>
   {% endif %}
 </div>

--- a/templates/layouts/two-column.html.twig
+++ b/templates/layouts/two-column.html.twig
@@ -1,15 +1,15 @@
 <div{{ attributes.addClass('jumpstart-ui--three-column', 'flex-container', settings.centered, settings.extra_classes) }}>
 
   {% if content.left|render %}
-    <aside {{ region_attributes.left.addClass('left-region', 'flex-lg-3-of-12') }}>
+    <div {{ region_attributes.left.addClass('left-region', 'flex-lg-3-of-12') }}>
       {{ content.left }}
-    </aside>
+    </div>
   {% endif %}
 
   {% if content.main|render %}
-    <section {{ region_attributes.main.addClass('main-region', content.left|render  ? 'flex-lg-9-of-12' : '') }}>
+    <div {{ region_attributes.main.addClass('main-region', content.left|render  ? 'flex-lg-9-of-12' : '') }}>
       {{ content.main }}
-    </section>
+    </div>
   {% endif %}
 
 </div>


### PR DESCRIPTION
 since cannot predict content and using semantics wrong

# READY FOR REVIEW

# Summary
- This is to change the Jumpstart-UI templates to use divs instead of aside and section.

# Needed By (Date)
- RC1

# Urgency
- Must fix - low

# Steps to Test

1. Pull branch
2. Clear drush cache
3. View the site on the homepage, a page with a side bar, a page with the layout builder with 3 columns. 

# Affected Projects or Products
- It impacts the D8Core

# Associated Issues and/or People
- D8CORE-1250
- @cjwest 
- This relates to our accessibility initiative 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
