### PR TITLE
D8CORE-1233: Cannot assume attributes is being passed in.

### DIFF
--- a/dist/templates/decanter/components/hero/hero.twig
+++ b/dist/templates/decanter/components/hero/hero.twig
@@ -31,7 +31,6 @@
 {%- if template_path_card is empty -%}
   {%- set template_path_card = "@decanter/components/card/card.twig" -%}
 {%- endif -%}
-
 <div{{ attributes }} class="su-hero {{ modifier_class }}">
 
   {# Hero Image or Video #}

--- a/templates/components/alert/alert.html.twig
+++ b/templates/components/alert/alert.html.twig
@@ -1,8 +1,14 @@
 {# Override of Decanter's Core Template #}
-{% set attributes = attributes.removeClass('su-alert') %}
+{% if attributes is not empty %}
+  {% set attributes = attributes.removeClass('su-alert') %}
+{% else %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
 {% if modifier_class is not empty %}
   {% set attributes = attributes.addClass(modifier_class) %}
 {% endif %}
+
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 {% extends '@decanter/components/alert/alert.twig' %}

--- a/templates/components/brand-bar/brand-bar.html.twig
+++ b/templates/components/brand-bar/brand-bar.html.twig
@@ -1,8 +1,15 @@
 {# Glue code for Decanter's component #}
-{% set attributes = attributes.removeClass('su-brand-bar') %}
+{% if attributes is not empty %}
+  {% set attributes = attributes.removeClass('su-brand-bar') %}
+{% else %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
 {% if modifier_class is not empty %}
   {% set attributes = attributes.addClass(modifier_class) %}
 {% endif %}
+
 {% set modifier_class = attributes.class %}
+
 {% set attributes = attributes|without('class') %}
 {% extends '@decanter/components/brand-bar/brand-bar.twig' %}

--- a/templates/components/button/button.html.twig
+++ b/templates/components/button/button.html.twig
@@ -1,8 +1,14 @@
 {# Glue code for Decanter's component #}
-{% set attributes = attributes.removeClass('su-button') %}
+{% if attributes is not empty %}
+  {% set attributes = attributes.removeClass('su-button') %}
+{% else %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
 {% if modifier_class is not empty %}
   {% set attributes = attributes.addClass(modifier_class) %}
 {% endif %}
+
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class', 'value', 'name', 'type') %}
 {% extends '@decanter/components/button/button.twig' %}

--- a/templates/components/card/card.html.twig
+++ b/templates/components/card/card.html.twig
@@ -15,11 +15,17 @@
   {{ card_media_custom }}
 {% endblock %}
 
-{% set attributes = attributes.removeClass('su-card') %}
+{% if attributes is not empty %}
+  {% set attributes = attributes.removeClass('su-card') %}
+{% else %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
 {% if modifier_class is not empty %}
   {% set attributes = attributes.addClass(modifier_class) %}
 {% endif %}
+
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 
-{% extends "@decanter/components/card/card.twig" %}
+{% include "@decanter/components/card/card.twig" %}

--- a/templates/components/card/card.html.twig
+++ b/templates/components/card/card.html.twig
@@ -28,4 +28,4 @@
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 
-{% include "@decanter/components/card/card.twig" %}
+{% extends "@decanter/components/card/card.twig" %}

--- a/templates/components/cta/cta.html.twig
+++ b/templates/components/cta/cta.html.twig
@@ -1,8 +1,14 @@
 {# Glue code for Decanter's component #}
-{% set attributes = attributes.removeClass('su-cta') %}
+{% if attributes is not empty %}
+  {% set attributes = attributes.removeClass('su-cta') %}
+{% else %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
 {% if modifier_class is not empty %}
   {% set attributes = attributes.addClass(modifier_class) %}
 {% endif %}
+
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class', 'href') %}
 {% extends "@decanter/components/cta/cta.twig" %}

--- a/templates/components/date-stacked/date-stacked.html.twig
+++ b/templates/components/date-stacked/date-stacked.html.twig
@@ -1,8 +1,14 @@
 {# Glue code for Decanter's component #}
-{% set attributes = attributes.removeClass('su-date-stacked') %}
+{% if attributes is not empty %}
+  {% set attributes = attributes.removeClass('su-date-stacked') %}
+{% else %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
 {% if modifier_class is not empty %}
   {% set attributes = attributes.addClass(modifier_class) %}
 {% endif %}
+
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 {% extends "@decanter/components/date-stacked/date-stacked.twig" %}

--- a/templates/components/global-footer/global-footer.html.twig
+++ b/templates/components/global-footer/global-footer.html.twig
@@ -1,8 +1,14 @@
 {# Glue code for Decanter's component #}
-{% set attributes = attributes.removeClass('su-global-footer') %}
+{% if attributes is not empty %}
+  {% set attributes = attributes.removeClass('su-global-footer') %}
+{% else %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
 {% if modifier_class is not empty %}
   {% set attributes = attributes.addClass(modifier_class) %}
 {% endif %}
+
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 {% extends "@decanter/components/global-footer/global-footer.twig" %}

--- a/templates/components/hero/hero.html.twig
+++ b/templates/components/hero/hero.html.twig
@@ -47,10 +47,16 @@
 #}
 {%- set template_path_card = "@jumpstart_ui/components/card/card.html.twig" -%}
 
-{% set attributes = attributes.removeClass('su-hero') %}
+{% if attributes is not empty %}
+  {% set attributes = attributes.removeClass('su-hero') %}
+{% else %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
 {% if modifier_class is not empty %}
   {% set attributes = attributes.addClass(modifier_class) %}
 {% endif %}
+
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 

--- a/templates/components/link/link.html.twig
+++ b/templates/components/link/link.html.twig
@@ -1,8 +1,14 @@
 {# Glue code for Decanter's component #}
-{% set attributes = attributes.removeClass('su-link') %}
+{% if attributes is not empty %}
+  {% set attributes = attributes.removeClass('su-link') %}
+{% else %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
 {% if modifier_class is not empty %}
   {% set attributes = attributes.addClass(modifier_class) %}
 {% endif %}
+
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class', 'href') %}
 {% extends '@decanter/components/link/link.twig' %}

--- a/templates/components/local-footer/local-footer.html.twig
+++ b/templates/components/local-footer/local-footer.html.twig
@@ -17,10 +17,16 @@
 {%- set primary_links_header = primary_links_header|render|striptags('<drupal-render-placeholder><a>')|trim -%}
 {%- set secondary_links_header = secondary_links_header|render|striptags('<drupal-render-placeholder><a>')|trim -%}
 
-{% set attributes = attributes.removeClass('su-local-footer') %}
+{% if attributes is not empty %}
+  {% set attributes = attributes.removeClass('su-local-footer') %}
+{% else %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
 {% if modifier_class is not empty %}
   {% set attributes = attributes.addClass(modifier_class) %}
 {% endif %}
+
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 

--- a/templates/components/lockup/lockup.html.twig
+++ b/templates/components/lockup/lockup.html.twig
@@ -1,8 +1,15 @@
 {# Glue code for Decanter's component #}
-{% set attributes = attributes.removeClass('su-lockup') %}
+{% if attributes is not empty %}
+  {% set attributes = attributes.removeClass('su-lockup') %}
+{% else %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
 {% if modifier_class is not empty %}
   {% set attributes = attributes.addClass(modifier_class) %}
 {% endif %}
+
 {% set modifier_class = attributes.class %}
+
 {% set attributes = attributes|without('class') %}
 {% extends '@decanter/components/lockup/lockup.twig' %}

--- a/templates/components/logo/logo.html.twig
+++ b/templates/components/logo/logo.html.twig
@@ -1,8 +1,14 @@
 {# Glue code for Decanter's component #}
-{% set attributes = attributes.removeClass('su-logo') %}
+{% if attributes is not empty %}
+  {% set attributes = attributes.removeClass('su-logo') %}
+{% else %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
 {% if modifier_class is not empty %}
   {% set attributes = attributes.addClass(modifier_class) %}
 {% endif %}
+
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class', 'href') %}
 {% extends '@decanter/components/logo/logo.twig' %}

--- a/templates/components/media/media.html.twig
+++ b/templates/components/media/media.html.twig
@@ -1,8 +1,14 @@
 {%- set media_link = media_link|render|striptags('<drupal-render-placeholder>') -%}
-{% set attributes = attributes.removeClass('su-media') %}
+{% if attributes is not empty %}
+  {% set attributes = attributes.removeClass('su-media') %}
+{% else %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
 {% if modifier_class is not empty %}
   {% set attributes = attributes.addClass(modifier_class) %}
 {% endif %}
+
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 

--- a/templates/components/quote/quote.html.twig
+++ b/templates/components/quote/quote.html.twig
@@ -1,8 +1,14 @@
 {# Glue code for Decanter's component #}
-{% set attributes = attributes.removeClass('su-quote') %}
+{% if attributes is not empty %}
+  {% set attributes = attributes.removeClass('su-quote') %}
+{% else %}
+  {% set attributes = create_attribute() %}
+{% endif %}
+
 {% if modifier_class is not empty %}
   {% set attributes = attributes.addClass(modifier_class) %}
 {% endif %}
+
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 {% extends '@decanter/components/quote/quote.twig' %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Ensures attributes is a valid attribute object before manipulations
- Allows modifier_class and attributes to be passed correctly to nested components.

# Review By (Date)
- Feb 12th

# Urgency
- Medium, required for 1.0.0 release

# Steps to Test

1. Spin up a local build of acsf-cardinalsites from the 1.x branch (if you have one already use it)
2. Do a full site install and review the home page (Only if you need a fresh copy)
3. Review the home page hero and see that the content overlay is missing
4. Check out this branch and clear caches
5. Review the home page hero's and see that the content overlay is back

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- D8CORE-1233
- @FYI @kerri-augenstein 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
