### PR TITLE
jumpstart-ui--three-column to jumpstart-ui--two-column

### DIFF
--- a/templates/layouts/two-column.html.twig
+++ b/templates/layouts/two-column.html.twig
@@ -1,4 +1,4 @@
-<div{{ attributes.addClass('jumpstart-ui--three-column', 'flex-container', settings.centered, settings.extra_classes) }}>
+<div{{ attributes.addClass('jumpstart-ui--two-column', 'flex-container', settings.centered, settings.extra_classes) }}>
 
   {% if content.left|render %}
     <div {{ region_attributes.left.addClass('left-region', 'flex-lg-3-of-12') }}>


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Change layout for two column class back to jumpstart-ui--two-column

# Review By (Date)
- Feb 13

# Urgency
- Low

# Steps to Test

1. Review code
2. Check out this branch
3. Place a two column layout in layout builder and add a couple of blocks
4. Save and review the output

# Affected Projects or Products
- D8CORE

# Associated Issues and/or People
-  D8CORE-1261
- FYI @cjwest 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
