### PR TITLE
D8CORE-1398: Fix broken link mapping for hero button.

### DIFF
--- a/templates/components/hero/hero.html.twig
+++ b/templates/components/hero/hero.html.twig
@@ -60,6 +60,10 @@
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 
+{% if hero_link is empty and hero_button_link is not empty %}
+  {% set hero_link = hero_button_link %}
+{% endif %}
+
 {#
   Include the template.
 #}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixes up the broken link on banner buttons.

# Review By (Date)
- End of the week?

# Urgency
- Highish

# Steps to Test

1. If you have an existing local check out this branch and clear cache. Otherwise, check out this branch and run an install.
2. Create a stanford_page type and add a banner and fill in the link fields
3. Validate the link shows up as it should.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- D8CORE-1398

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
