### PR TITLE
D8CORE-1427: Remove render array junk when checking for empty on hero_link variable in hero.html.twig template

### DIFF
--- a/templates/components/card/card.html.twig
+++ b/templates/components/card/card.html.twig
@@ -3,6 +3,7 @@
  #}
 {%- set card_cta_label = card_cta_label|render|striptags('<drupal-render-placeholder>') -%}
 {%- set card_link = card_link|render|striptags('<drupal-render-placeholder>') -%}
+
 {#
   You are not allowed to have both action and button at the same time so remove the button
 #}
@@ -10,11 +11,17 @@
   {% set card_button_label = null %}
 {% endif %}
 
+{#
+  Override the media section as Drupal has it's own output.
+#}
 {% block block_card_media %}
   {{ card_image }}
   {{ card_media_custom }}
 {% endblock %}
 
+{#
+  Attributes get passed along so we need to ensure only what we want trickles down to the nested templates.
+#}
 {% if attributes is not empty %}
   {% set attributes = attributes.removeClass('su-card') %}
 {% else %}

--- a/templates/components/hero/hero.html.twig
+++ b/templates/components/hero/hero.html.twig
@@ -60,7 +60,7 @@
 {% set modifier_class = attributes.class %}
 {% set attributes = attributes|without('class') %}
 
-{% if hero_link is empty and hero_button_link is not empty %}
+{% if hero_link is empty and hero_button_link|render|striptags('<drupal-render-placeholder>') is not empty %}
   {% set hero_link = hero_button_link %}
 {% endif %}
 


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Accurately shows/hides the card overlay on banners.
- Fixes bug in empty check.

# Needed By (Date)
- Thursday Morning

# Urgency
- High, has prominent visibility. 

# Steps to Test

1. Do a build or use your current build of stanford_profile in the cardinalsites stack
2. Create a new banner paragraph on a new stanford_page node and add an image but do not fill in any other field.
3. Save the node and view the output. You should see an empty white box over the banner image
4. Check out this branch and clear all caches. 
5. Refresh the page and you should not see the white box over the image
6. Edit the node and add in heading text and a button link
7. Save and view the page. You should see the new headings and button.

# Affected Projects or Products
- D8CORE

# Associated Issues and/or People
- D8CORE-1427

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
