### PR TITLE
D8CORE-1457: Allow special chars in urls.

### DIFF
--- a/templates/components/local-footer/local-footer.html.twig
+++ b/templates/components/local-footer/local-footer.html.twig
@@ -8,7 +8,7 @@
 {%- endif -%}
 {%- set lockup_title = lockup_title|render|striptags('<drupal-render-placeholder>')|trim -%}
 {%- set signup_form_method = signup_form_method|render|striptags('<drupal-render-placeholder>')|trim -%}
-{%- set signup_form_action = signup_form_action|render|striptags('<drupal-render-placeholder>')|trim -%}
+{%- set signup_form_action = signup_form_action|render|striptags('<drupal-render-placeholder>')|trim|convert_encoding('UTF-8', 'HTML-ENTITIES') -%}
 {%- set signup_form_field_submit_value = signup_form_field_submit_value|render|striptags('<drupal-render-placeholder>')|trim -%}
 {%- set action_links = linklist.create_list(action_links) -%}
 {%- set social_links = sociallist.create_list(social_links) -%}


### PR DESCRIPTION
Re: https://createdbycocoon.com/knowledge/render-html-special-characters-twig-striptags-drupal

# READY FOR REVIEW 

# Summary
- Allows special characters in the url after render|striptags is called.

# Needed By (Date)
- Thursday

# Urgency
- Medium

# Steps to Test

1. On your 1.x build of stanford_profile edit the local-footer config form
2. Add a value for the signup form action: `https://example.com/?what=dis&where=dat`
3. Save, reload the page, and inspect form action. 
4. See `&amp;` in url
5. Check out this branch and clear the cache
6. Re-inspect action property on the form
7. See `&`s again.

# Affected Projects or Products
- D8CORE

# Associated Issues and/or People
- D8CORE-1457

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
