### PR TITLE
D8CORE-1327: Footer lockup escape extra characters.

### DIFF
--- a/templates/components/local-footer/local-footer.html.twig
+++ b/templates/components/local-footer/local-footer.html.twig
@@ -6,7 +6,7 @@
 {%- if weblogin_text is empty -%}
   {%- set weblogin_url = '' -%}
 {%- endif -%}
-{%- set lockup_title = lockup_title|render|striptags('<drupal-render-placeholder>')|trim -%}
+{%- set lockup_title = lockup_title|render|striptags('<drupal-render-placeholder>')|trim|convert_encoding('UTF-8', 'HTML-ENTITIES') -%}
 {%- set signup_form_method = signup_form_method|render|striptags('<drupal-render-placeholder>')|trim -%}
 {%- set signup_form_action = signup_form_action|render|striptags('<drupal-render-placeholder>')|trim|convert_encoding('UTF-8', 'HTML-ENTITIES') -%}
 {%- set signup_form_field_submit_value = signup_form_field_submit_value|render|striptags('<drupal-render-placeholder>')|trim -%}


### PR DESCRIPTION
Note: I'm not sure why I have the stuff from the Update to Decanter 6.0.4. I switched to the master and I thought that was a clean way to do that. But now I'm not sure. What do you think?

# NOT READY FOR REVIEW

# Summary
- Currently, html entities are encoded and passed into the twig templates rendering & as &amp; This is particularly a problem for the header and footer's lockup.
-This is for the footer lockup.

# Review By (Date)
- Thursday 

# Urgency
- Med/Low

# Steps to Test

1. Set the site name to Bugs & 'Bunny'
2. Clear cache and review the local footer lockup
3. See double encoding of the &
4. See the ' encoded.
5. Check out this branch and import config
6. Clear cache and see only the & and the '
6. Shea fixed up the double encoding in the config.

# Affected Projects or Products
- D8CORE-1327

# Associated Issues and/or People
- D8CORE-1327
- https://github.com/SU-SWS/stanford_profile/pull/123
- https://github.com/SU-SWS/jumpstart_ui/compare/D8CORE-1327
- @sherakama 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
