### PR TITLE
DCORE-1504: Ensure unique id's in the media template.

### DIFF
--- a/jumpstart_ui.module
+++ b/jumpstart_ui.module
@@ -39,20 +39,10 @@ function jumpstart_ui_preprocess(&$variables, $hook) {
 
   foreach (UiPatterns::getPatternDefinitions() as $pattern_id => $pattern) {
     if (strpos($hook, $pattern_id) !== FALSE) {
-      $ids = &drupal_static(__FUNCTION__, []);
-      if (!isset($ids[$pattern_id])) {
-        $ids[$pattern_id] = 0;
-      }
-
-      if (!isset($variables['attributes']['id'])) {
-        $variables['attributes']['id'] = Html::getUniqueId($pattern_id);
-      }
-
       $definition = $pattern->toArray();
       if (isset($variables['variant']) && isset($definition['variants'][$variables['variant']]['modifier_class'])) {
         $variables['modifier_class'] = $definition['variants'][$variables['variant']]['modifier_class'];
       }
-
       break;
     }
   }

--- a/jumpstart_ui.module
+++ b/jumpstart_ui.module
@@ -40,11 +40,6 @@ function jumpstart_ui_preprocess(&$variables, $hook) {
   foreach (UiPatterns::getPatternDefinitions() as $pattern_id => $pattern) {
     if (strpos($hook, $pattern_id) !== FALSE) {
 
-      $ids = &drupal_static(__FUNCTION__, []);
-      if (!isset($ids[$pattern_id])) {
-        $ids[$pattern_id] = 0;
-      }
-
       if (isset($variables['attributes']['id'])) {
         $variables['attributes']['id'] = Html::getUniqueId($pattern_id);
       }

--- a/jumpstart_ui.module
+++ b/jumpstart_ui.module
@@ -7,6 +7,7 @@
  * Long description.
  */
 
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Url;
 use Drupal\ui_patterns\UiPatterns;
 
@@ -38,6 +39,16 @@ function jumpstart_ui_preprocess(&$variables, $hook) {
 
   foreach (UiPatterns::getPatternDefinitions() as $pattern_id => $pattern) {
     if (strpos($hook, $pattern_id) !== FALSE) {
+
+      $ids = &drupal_static(__FUNCTION__, []);
+      if (!isset($ids[$pattern_id])) {
+        $ids[$pattern_id] = 0;
+      }
+
+      if (isset($variables['attributes']['id'])) {
+        $variables['attributes']['id'] = Html::getUniqueId($pattern_id);
+      }
+
       $definition = $pattern->toArray();
       if (isset($variables['variant']) && isset($definition['variants'][$variables['variant']]['modifier_class'])) {
         $variables['modifier_class'] = $definition['variants'][$variables['variant']]['modifier_class'];

--- a/jumpstart_ui.module
+++ b/jumpstart_ui.module
@@ -41,7 +41,7 @@ function jumpstart_ui_preprocess(&$variables, $hook) {
     if (strpos($hook, $pattern_id) !== FALSE) {
 
       if (isset($variables['attributes']['id'])) {
-        $variables['attributes']['id'] = Html::getUniqueId($pattern_id);
+        $variables['attributes']['id'] = Html::getUniqueId($variables['attributes']['id']);
       }
 
       $definition = $pattern->toArray();

--- a/jumpstart_ui.module
+++ b/jumpstart_ui.module
@@ -10,6 +10,7 @@
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Url;
 use Drupal\ui_patterns\UiPatterns;
+use Drupal\ui_patterns\Element\PatternContext;
 
 /**
  * Implements hook_page_attachments().
@@ -32,11 +33,13 @@ function jumpstart_ui_page_attachments(array &$page) {
  * Implements hook_preprocess().
  */
 function jumpstart_ui_preprocess(&$variables, $hook) {
-  $moduleHandler = \Drupal::service('module_handler');
-  if (!$moduleHandler->moduleExists('ui_patterns')) {
+
+  // Only want pattern contexts.
+  if (isset($variables['context']) && !($variables['context'] instanceof PatternContext)) {
     return;
   }
 
+  // Match the hook with a strpos because it is not consistent.
   foreach (UiPatterns::getPatternDefinitions() as $pattern_id => $pattern) {
     if (strpos($hook, $pattern_id) !== FALSE) {
 

--- a/jumpstart_ui.module
+++ b/jumpstart_ui.module
@@ -7,7 +7,6 @@
  * Long description.
  */
 
-use Drupal\Component\Utility\Html;
 use Drupal\Core\Url;
 use Drupal\ui_patterns\UiPatterns;
 

--- a/templates/components/media/media.html.twig
+++ b/templates/components/media/media.html.twig
@@ -1,6 +1,11 @@
 {%- set media_link = media_link|render|striptags('<drupal-render-placeholder>') -%}
 {% if attributes is not empty %}
   {% set attributes = attributes.removeClass('su-media') %}
+  {#
+    D8CORE-154: Ensure unqiue ids by changing the ID that is automatically provided by ui_patterns_ds.
+    It is unfortunate that this template is called `media` and that we render a `media` item within.
+  #}
+  {% set attributes = attributes.setAttribute('id', getUniqueId('su-media')) %}
 {% else %}
   {% set attributes = create_attribute() %}
 {% endif %}

--- a/templates/components/media/media.html.twig
+++ b/templates/components/media/media.html.twig
@@ -1,11 +1,6 @@
 {%- set media_link = media_link|render|striptags('<drupal-render-placeholder>') -%}
 {% if attributes is not empty %}
   {% set attributes = attributes.removeClass('su-media') %}
-  {#
-    D8CORE-154: Ensure unqiue ids by changing the ID that is automatically provided by ui_patterns_ds.
-    It is unfortunate that this template is called `media` and that we render a `media` item within.
-  #}
-  {% set attributes = attributes.setAttribute('id', getUniqueId('su-media')) %}
 {% else %}
   {% set attributes = create_attribute() %}
 {% endif %}

--- a/tests/src/Kernel/Pattern/PatternMediaTest.php
+++ b/tests/src/Kernel/Pattern/PatternMediaTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\Tests\jumpstart_ui\Kernel\Pattern;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Drupal\Core\Template\Attribute;
+
+/**
+ * Class PatternMediaTest.
+ *
+ * @group jumpstart_ui
+ */
+class PatternMediaTest extends KernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'system',
+    'jumpstart_ui'
+  ];
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container) {
+    parent::register($container);
+
+    $container->setDefinition('twig_loader__file_system', new Definition('Twig_Loader_Filesystem', [[dirname(__FILE__, 5) . '/templates/components/']]))
+      ->addTag('twig.loader');
+  }
+
+  /**
+   * Pattern should not produce duplicate ids.
+   */
+  public function testMediaPatternIds() {
+    // Boot twig environment.
+    $twig =  \Drupal::service('twig');
+    $template = drupal_get_path('module', 'jumpstart_ui') . '/templates/components/media/media.html.twig';
+    $props = [
+      'media_caption' => ["Well, hello there. I am a caption."],
+      'media_custom' => ['<div class="media">Nothing to see here, please move along.</div>'],
+      'attributes' => new Attribute(['class' => 'su-media', 'id' => 'su-media']),
+    ];
+    $this->setRawContent((string) twig_render_template($template, $props));
+    $this->assertText("Well, hello there. I am a caption.");
+    $this->assertContains("https://placeimg.com/2000/1333/any", $this->getRawContent());
+    $this->assertContains("id=\"su-media\"", $this->getRawContent());
+
+    $this->setRawContent((string) twig_render_template($template, $props));
+    $this->assertText("Well, hello there. I am a caption.");
+    $this->assertContains("https://placeimg.com/2000/1333/any", $this->getRawContent());
+    $this->assertContains("id=\"su-media--2\"", $this->getRawContent());
+
+    $this->setRawContent((string) twig_render_template($template, $props));
+    $this->assertText("Well, hello there. I am a caption.");
+    $this->assertContains("https://placeimg.com/2000/1333/any", $this->getRawContent());
+    $this->assertContains("id=\"su-media--2\"", $this->getRawContent());
+  }
+
+}

--- a/tests/src/Kernel/Pattern/PatternMediaTest.php
+++ b/tests/src/Kernel/Pattern/PatternMediaTest.php
@@ -69,7 +69,7 @@ class PatternMediaTest extends KernelTestBase {
    */
   public function testMediaPatternIds() {
     $props = [
-      'attributes' => new Attribute(['class' => 'su-media', 'id' => 'media']),
+      'attributes' => new Attribute(['class' => 'su-media', 'id' => 'su-media']),
       'media_caption' => 'You must do the things you think you cannot do.',
       'media_custom' => 'Nothing to see here. Please move along',
     ];

--- a/tests/src/Kernel/Pattern/PatternMediaTest.php
+++ b/tests/src/Kernel/Pattern/PatternMediaTest.php
@@ -21,9 +21,19 @@ class PatternMediaTest extends KernelTestBase {
    */
   public static $modules = [
     'system',
-    'jumpstart_ui'
+    'jumpstart_ui',
+    'components',
+    'file',
+    'ui_patterns',
+    'ui_patterns_ds',
+    'node',
+    'user'
   ];
 
+  public function setup() {
+    parent::setup();
+    // $this->installSchema('components', 'settings');
+  }
 
   /**
    * {@inheritdoc}
@@ -31,7 +41,14 @@ class PatternMediaTest extends KernelTestBase {
   public function register(ContainerBuilder $container) {
     parent::register($container);
 
-    $container->setDefinition('twig_loader__file_system', new Definition('Twig_Loader_Filesystem', [[dirname(__FILE__, 5) . '/templates/components/']]))
+    $container->setDefinition('twig_loader__file_system', new Definition('Twig_Loader_Filesystem',
+      [
+        [
+          dirname(__FILE__, 5) . '/templates/components/',
+          dirname(__FILE__, 5) . '/dist/templates/'
+        ]
+      ]
+    ))
       ->addTag('twig.loader');
   }
 

--- a/tests/src/Kernel/Pattern/PatternMediaTest.php
+++ b/tests/src/Kernel/Pattern/PatternMediaTest.php
@@ -3,8 +3,6 @@
 namespace Drupal\Tests\jumpstart_ui\Kernel\Pattern;
 
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\Core\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Drupal\Core\Template\Attribute;
 use Twig\TemplateWrapper;
 
@@ -63,7 +61,7 @@ class PatternMediaTest extends KernelTestBase {
     $this->assertTwigTemplate($this->twig->load('@jumpstart_ui/components/card/card.html.twig'), 'Found card.html.twig in jumpstart_ui module.');
 
     // Tests resolving namespaced templates in the Decanter templates.
-    $this->assertTwigTemplate($this->twig->load('@decanter/components/card/card.twig'), 'Found card.html.twig in jumpstart_ui module.');
+    $this->assertTwigTemplate($this->twig->load('@decanter/components/card/card.twig'), 'Found card.twig in jumpstart_ui module.');
   }
 
   /**

--- a/tests/src/Kernel/Pattern/PatternMediaTest.php
+++ b/tests/src/Kernel/Pattern/PatternMediaTest.php
@@ -5,6 +5,8 @@ namespace Drupal\Tests\jumpstart_ui\Kernel\Pattern;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Core\Template\Attribute;
 use Twig\TemplateWrapper;
+use Drupal\ui_patterns\Element\PatternContext;
+use Drupal\Component\Utility\Html;
 
 /**
  * Class PatternMediaTest.
@@ -68,23 +70,46 @@ class PatternMediaTest extends KernelTestBase {
    * Pattern should not produce duplicate ids.
    */
   public function testMediaPatternIds() {
-    $props = [
-      'attributes' => new Attribute(['class' => 'su-media', 'id' => 'su-media']),
-      'media_caption' => 'You must do the things you think you cannot do.',
-      'media_custom' => 'Nothing to see here. Please move along',
-    ];
     $template = drupal_get_path('module', 'jumpstart_ui') . "/templates/components/media/media.html.twig";
+    $props = $this->getProps();
     $this->setRawContent((string) twig_render_template($template, $props));
 
     $this->assertText("You must do the things you think you cannot do");
     $this->assertText("Nothing to see here");
     $this->assertContains("id=\"su-media\"", $this->getRawContent());
 
+    $props = $this->getProps();
     $this->setRawContent((string) twig_render_template($template, $props));
     $this->assertContains("id=\"su-media--2\"", $this->getRawContent());
 
+    $props = $this->getProps();
     $this->setRawContent((string) twig_render_template($template, $props));
     $this->assertContains("id=\"su-media--3\"", $this->getRawContent());
+  }
+
+  /**
+   * [getProps description]
+   * @return [type] [description]
+   */
+  protected function getProps() {
+    $props = [
+      'attributes' => ['class' => 'su-media', 'id' => 'su-media'],
+      'media_caption' => 'You must do the things you think you cannot do.',
+      'media_custom' => 'Nothing to see here. Please move along',
+      'context' => new PatternContext('empty'),
+    ];
+    $this->fakeJumpstartUIPreproces($props, 'pattern_media');
+    $props['attributes'] = new Attribute($props['attributes']);
+    return $props;
+  }
+
+  /**
+   * fake parts of the preprocess function.
+   */
+  protected function fakeJumpstartUIPreproces(&$variables, $hook) {
+    if (isset($variables['attributes']['id'])) {
+      $variables['attributes']['id'] = Html::getUniqueId($variables['attributes']['id']);
+    }
   }
 
 }

--- a/tests/src/Kernel/Pattern/PatternMediaTest.php
+++ b/tests/src/Kernel/Pattern/PatternMediaTest.php
@@ -6,6 +6,7 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Drupal\Core\Template\Attribute;
+use Twig\TemplateWrapper;
 
 /**
  * Class PatternMediaTest.
@@ -27,57 +28,65 @@ class PatternMediaTest extends KernelTestBase {
     'ui_patterns',
     'ui_patterns_ds',
     'node',
-    'user'
+    'user',
   ];
 
-  public function setup() {
-    parent::setup();
-    // $this->installSchema('components', 'settings');
+  /**
+   * @var \Drupal\Core\Template\TwigEnvironment
+   */
+  protected $twig;
+
+  /**
+   * Setup.
+   */
+  protected function setUp() {
+    parent::setUp();
+    \Drupal::service('theme_installer')->install(['bartik']);
+    $this->twig = \Drupal::service('twig');
   }
 
   /**
-   * {@inheritdoc}
+   * Checks to see if a value is a twig template.
    */
-  public function register(ContainerBuilder $container) {
-    parent::register($container);
+  public function assertTwigTemplate($value, $message = '', $group = 'Other') {
+    $this->assertTrue($value instanceof TemplateWrapper, $message, $group);
+  }
 
-    $container->setDefinition('twig_loader__file_system', new Definition('Twig_Loader_Filesystem',
-      [
-        [
-          dirname(__FILE__, 5) . '/templates/components/',
-          dirname(__FILE__, 5) . '/dist/templates/'
-        ]
-      ]
-    ))
-      ->addTag('twig.loader');
+  /**
+   * Check to see if twig namespaces are working.
+   */
+  public function testTwigNamespaces() {
+    // Tests resolving namespaced templates in modules.
+    $this->assertTwigTemplate($this->twig->load('@node/node.html.twig'), 'Found node.html.twig in node module.');
+
+    // Tests resolving namespaced templates in jumpstart_ui.
+    $this->assertTwigTemplate($this->twig->load('@jumpstart_ui/components/card/card.html.twig'), 'Found card.html.twig in jumpstart_ui module.');
+
+    // Tests resolving namespaced templates in the Decanter templates.
+    $this->assertTwigTemplate($this->twig->load('@decanter/components/card/card.twig'), 'Found card.html.twig in jumpstart_ui module.');
   }
 
   /**
    * Pattern should not produce duplicate ids.
    */
   public function testMediaPatternIds() {
-    // Boot twig environment.
-    $twig =  \Drupal::service('twig');
-    $template = drupal_get_path('module', 'jumpstart_ui') . '/templates/components/media/media.html.twig';
     $props = [
-      'media_caption' => ["Well, hello there. I am a caption."],
-      'media_custom' => ['<div class="media">Nothing to see here, please move along.</div>'],
-      'attributes' => new Attribute(['class' => 'su-media', 'id' => 'su-media']),
+      'attributes' => new Attribute(['class' => 'su-media', 'id' => 'media']),
+      'media_caption' => 'You must do the things you think you cannot do.',
+      'media_custom' => 'Nothing to see here. Please move along',
     ];
+    $template = drupal_get_path('module', 'jumpstart_ui') . "/templates/components/media/media.html.twig";
     $this->setRawContent((string) twig_render_template($template, $props));
-    $this->assertText("Well, hello there. I am a caption.");
-    $this->assertContains("https://placeimg.com/2000/1333/any", $this->getRawContent());
+
+    $this->assertText("You must do the things you think you cannot do");
+    $this->assertText("Nothing to see here");
     $this->assertContains("id=\"su-media\"", $this->getRawContent());
 
     $this->setRawContent((string) twig_render_template($template, $props));
-    $this->assertText("Well, hello there. I am a caption.");
-    $this->assertContains("https://placeimg.com/2000/1333/any", $this->getRawContent());
     $this->assertContains("id=\"su-media--2\"", $this->getRawContent());
 
     $this->setRawContent((string) twig_render_template($template, $props));
-    $this->assertText("Well, hello there. I am a caption.");
-    $this->assertContains("https://placeimg.com/2000/1333/any", $this->getRawContent());
-    $this->assertContains("id=\"su-media--2\"", $this->getRawContent());
+    $this->assertContains("id=\"su-media--3\"", $this->getRawContent());
   }
 
 }


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- https://stanfordits.atlassian.net/browse/D8CORE-1504
- Stop adding IDs. 

# Needed By (Date)
- Would be nice for 1.0.1

# Urgency
- Medium

# Steps to Test

1. Review markup or use validator on: https://amptesting.sites.stanford.edu/banners-cards-media/media and see multiple ids with the `media--` prefix.
2. Check out this branch and build a site
3. Create a page with multiple media with caption paragraphs
4. Review markup and see outer-most wrapper id is now `su-media--` instead.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
