### PR TITLE
Add max columns for one column layout.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "drupal/core": "^8.8",
     "drupal/components": "~1.0",
     "drupal/ds": "~3.3",
-    "drupal/ui_patterns": "~1.0"
+    "drupal/ui_patterns": "~1.0",
+    "drupal/ui_patterns_layout_builder": "dev-8.x-1.x#e893ab24de2397c31f15aa480a3d4bf9a69cedda"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     "drupal/core": "^8.8",
     "drupal/components": "~1.0",
     "drupal/ds": "~3.3",
-    "drupal/ui_patterns": "~1.0",
-    "drupal/ui_patterns_layout_builder": "dev-8.x-1.x#e893ab24de2397c31f15aa480a3d4bf9a69cedda"
+    "drupal/ui_patterns": "~1.0"
   }
 }

--- a/dist/css/jumpstart_ui.layout.css
+++ b/dist/css/jumpstart_ui.layout.css
@@ -1,1 +1,1 @@
-.centered-content div:first-child{margin-left:auto;margin-right:auto}
+.centered-content>div:first-child{margin-left:auto;margin-right:auto}

--- a/dist/css/jumpstart_ui.layout.css
+++ b/dist/css/jumpstart_ui.layout.css
@@ -1,1 +1,1 @@
-.centered-content:first-child{margin-right:auto;margin-left:auto}
+.centered-content div:first-child{margin-left:auto;margin-right:auto}

--- a/dist/css/jumpstart_ui.layout.css
+++ b/dist/css/jumpstart_ui.layout.css
@@ -1,0 +1,1 @@
+.centered-content:first-child{margin-right:auto;margin-left:auto}

--- a/jumpstart_ui.layouts.yml
+++ b/jumpstart_ui.layouts.yml
@@ -32,6 +32,7 @@ jumpstart_ui_two_column:
 # Three Column
 jumpstart_ui_three_column:
   <<: *defaults
+  class: '\Drupal\jumpstart_ui\Layouts\JumpstartUiThreeColumnLayout'
   label: Stanford Three Column
   template: three-column
   icon_map:

--- a/lib/scss/jumpstart_ui.layout.scss
+++ b/lib/scss/jumpstart_ui.layout.scss
@@ -2,10 +2,11 @@
 
 // Jumpstart UI Specific Configuration and variable overrides.
 @import './jumpstart_ui.config';
-@import 'decanter/core/src/scss/decanter-no-markup';
+// @import 'decanter/core/src/scss/decanter-no-markup';
 
 .centered-content {
-  &:first-child {
-    @include margin(null auto);
+  div:first-child {
+    margin-left: auto;
+    margin-right: auto;
   }
 }

--- a/lib/scss/jumpstart_ui.layout.scss
+++ b/lib/scss/jumpstart_ui.layout.scss
@@ -2,10 +2,10 @@
 
 // Jumpstart UI Specific Configuration and variable overrides.
 @import './jumpstart_ui.config';
-// @import 'decanter/core/src/scss/decanter-no-markup';
-//
-// // Render Decanter Library Base Styles Only.
-// @import 'decanter/core/src/scss/layout/index';
-//
-// // Jumpstart UI Custom Styles
-// @import './layouts/index';
+@import 'decanter/core/src/scss/decanter-no-markup';
+
+.centered-content {
+  &:first-child {
+    @include margin(null auto);
+  }
+}

--- a/lib/scss/jumpstart_ui.layout.scss
+++ b/lib/scss/jumpstart_ui.layout.scss
@@ -5,7 +5,7 @@
 // @import 'decanter/core/src/scss/decanter-no-markup';
 
 .centered-content {
-  div:first-child {
+  > div:first-child {
     margin-left: auto;
     margin-right: auto;
   }

--- a/src/Layouts/JumpstartUiLayouts.php
+++ b/src/Layouts/JumpstartUiLayouts.php
@@ -17,7 +17,7 @@ class JumpstartUiLayouts extends LayoutDefault implements PluginFormInterface {
    * {@inheritDoc}
    */
   public function defaultConfiguration() {
-    return ['extra_classes' => NULL, 'centered' => TRUE];
+    return ['extra_classes' => NULL, 'centered' => TRUE, 'columns' => 'default'];
   }
 
   /**
@@ -25,17 +25,43 @@ class JumpstartUiLayouts extends LayoutDefault implements PluginFormInterface {
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     $form = [];
+
+    // Extra CSS classes.
     $form['extra_classes'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Extra Classes'),
       '#description' => $this->t('Add extra classes to the layout container.'),
       '#default_value' => $this->configuration['extra_classes'],
     ];
+
+    // Centered container.
     $form['centered'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Centered Container'),
       '#default_value' => (bool) $this->configuration['centered'],
     ];
+
+    // Columns.
+    $form['columns'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Maximum Width'),
+      '#description' => $this->t('Set the maximum width of the container.'),
+      '#options' => [
+        'default' => $this->t('default'),
+        'flex-3-of-12' => $this->t('3 Columns'),
+        'flex-4-of-12' => $this->t('4 Columns'),
+        'flex-5-of-12' => $this->t('5 Columns'),
+        'flex-6-of-12' => $this->t('6 Columns'),
+        'flex-7-of-12' => $this->t('7 Columns'),
+        'flex-8-of-12' => $this->t('8 Columns'),
+        'flex-9-of-12' => $this->t('9 Columns'),
+        'flex-10-of-12' => $this->t('10 Columns'),
+        'flex-11-of-12' => $this->t('11 Columns'),
+        'flex-12-of-12' => $this->t('12 Columns'),
+      ],
+      '#default_value' => $this->configuration['columns'] ?: 'default',
+    ];
+
     return $form;
   }
 
@@ -51,6 +77,7 @@ class JumpstartUiLayouts extends LayoutDefault implements PluginFormInterface {
     array_walk($classes, 'trim');
     $this->configuration['extra_classes'] = implode(' ', array_filter($classes));
     $this->configuration['centered'] = $form_state->getValue('centered') ? 'centered-container' : NULL;
+    $this->configuration['columns'] = $form_state->getValue('columns') ?: 'default';
   }
 
 }

--- a/src/Layouts/JumpstartUiLayouts.php
+++ b/src/Layouts/JumpstartUiLayouts.php
@@ -47,7 +47,7 @@ class JumpstartUiLayouts extends LayoutDefault implements PluginFormInterface {
       '#title' => $this->t('Maximum Width'),
       '#description' => $this->t('Set the maximum width of the container.'),
       '#options' => [
-        'default' => $this->t('default'),
+        'default' => $this->t('Default'),
         'flex-3-of-12' => $this->t('3 Columns'),
         'flex-4-of-12' => $this->t('4 Columns'),
         'flex-5-of-12' => $this->t('5 Columns'),

--- a/src/Layouts/JumpstartUiLayouts.php
+++ b/src/Layouts/JumpstartUiLayouts.php
@@ -78,7 +78,7 @@ class JumpstartUiLayouts extends LayoutDefault implements PluginFormInterface {
     array_walk($classes, 'trim');
     $this->configuration['extra_classes'] = implode(' ', array_filter($classes));
     $this->configuration['centered'] = $form_state->getValue('centered') ? 'centered-container' : NULL;
-    $this->configuration['columns'] = $form_state->getValue('columns') ?? 'default';
+    $this->configuration['columns'] = $form_state->getValue('columns');
   }
 
 }

--- a/src/Layouts/JumpstartUiLayouts.php
+++ b/src/Layouts/JumpstartUiLayouts.php
@@ -59,7 +59,7 @@ class JumpstartUiLayouts extends LayoutDefault implements PluginFormInterface {
         'flex-11-of-12' => $this->t('11 Columns'),
         'flex-12-of-12' => $this->t('12 Columns'),
       ],
-      '#default_value' => $this->configuration['columns'] ?: 'default',
+      '#default_value' => $this->configuration['columns'] ?? 'default',
     ];
 
     return $form;
@@ -78,7 +78,7 @@ class JumpstartUiLayouts extends LayoutDefault implements PluginFormInterface {
     array_walk($classes, 'trim');
     $this->configuration['extra_classes'] = implode(' ', array_filter($classes));
     $this->configuration['centered'] = $form_state->getValue('centered') ? 'centered-container' : NULL;
-    $this->configuration['columns'] = $form_state->getValue('columns') ?: 'default';
+    $this->configuration['columns'] = $form_state->getValue('columns') ?? 'default';
   }
 
 }

--- a/src/Layouts/JumpstartUiLayouts.php
+++ b/src/Layouts/JumpstartUiLayouts.php
@@ -24,7 +24,7 @@ class JumpstartUiLayouts extends LayoutDefault implements PluginFormInterface {
    * {@inheritDoc}
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
-    $form = [];
+    $form = parent::buildConfigurationForm($form, $form_state);
 
     // Extra CSS classes.
     $form['extra_classes'] = [
@@ -69,6 +69,7 @@ class JumpstartUiLayouts extends LayoutDefault implements PluginFormInterface {
    * {@inheritDoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    parent::submitConfigurationForm($form, $form_state);
     $classes = explode(' ', $form_state->getValue('extra_classes'));
     $classes = array_map([
       '\Drupal\Component\Utility\Html',

--- a/src/Layouts/JumpstartUiThreeColumnLayout.php
+++ b/src/Layouts/JumpstartUiThreeColumnLayout.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\jumpstart_ui\Layouts;
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Configurable options for the three column layout.
+ *
+ * @package Drupal\jumpstart_ui\Layouts
+ */
+class JumpstartUiThreeColumnLayout extends JumpstartUiLayouts {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function defaultConfiguration() {
+    $config = parent::defaultConfiguration();
+    unset($config['columns']);
+    return $config;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildConfigurationForm($form, $form_state);
+    unset($form['columns']);
+    return $form;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    parent::submitConfigurationForm($form, $form_state);
+    unset($this->configuration['columns']);
+  }
+
+}

--- a/src/Layouts/JumpstartUiTwoColumnLayout.php
+++ b/src/Layouts/JumpstartUiTwoColumnLayout.php
@@ -31,6 +31,7 @@ class JumpstartUiTwoColumnLayout extends JumpstartUiLayouts {
    */
   public function defaultConfiguration() {
     $config = parent::defaultConfiguration();
+    unset($config['columns']);
     $config['orientation'] = self::RIGHT;
     return $config;
   }
@@ -40,6 +41,7 @@ class JumpstartUiTwoColumnLayout extends JumpstartUiLayouts {
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     $form = parent::buildConfigurationForm($form, $form_state);
+    unset($form['columns']);
     $form['orientation'] = [
       '#type' => 'select',
       '#title' => $this->t('Orientation'),
@@ -58,6 +60,7 @@ class JumpstartUiTwoColumnLayout extends JumpstartUiLayouts {
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
     parent::submitConfigurationForm($form, $form_state);
+    unset($this->configuration['columns']);
     $this->configuration['orientation'] = $form_state->getValue('orientation');
   }
 

--- a/templates/layouts/one-column.html.twig
+++ b/templates/layouts/one-column.html.twig
@@ -7,11 +7,11 @@
 {# Add a few classes to the outer wrapper by default. #}
 {% set attributes = attributes.addClass('jumpstart-ui--one-column', settings.centered, settings.extra_classes) %}
 
-{# Pull out the main attributes so they are easier to work with #}
+{# Pull out the main attributes so they are easier to work with. #}
 {% set main_attributes = region_attributes.main %}
 {% set main_attributes = main_attributes.addClass('main-region') %}
 
-{# Configuraiton for the main attributes #}
+{# Configuration for the main attributes. #}
 {% if 'centered-container' in settings.centered|render and main_attributes is iterable %}
   {% set main_attributes = main_attributes.addClass('flex-12-of-12') %}
 {% endif %}

--- a/templates/layouts/one-column.html.twig
+++ b/templates/layouts/one-column.html.twig
@@ -1,9 +1,31 @@
-{% if 'centered-container' in settings.centered|render and region_attributes.main is iterable %}
-  {% set region_attributes_main = region_attributes.main.addClass('flex-12-of-12') %}
-  {% set region_attributes = region_attributes|merge({'main': region_attributes_main}) %}
+{#
+  /**
+   * Single Column Container with configuration options.
+   */
+#}
+
+{# Add a few classes to the outer wrapper by default. #}
+{% set attributes = attributes.addClass('jumpstart-ui--one-column', settings.centered, settings.extra_classes) %}
+
+{# Pull out the main attributes so they are easier to work with #}
+{% set main_attributes = region_attributes.main %}
+{% set main_attributes = main_attributes.addClass('main-region') %}
+
+{# Configuraiton for the main attributes #}
+{% if 'centered-container' in settings.centered|render and main_attributes is iterable %}
+  {% set main_attributes = main_attributes.addClass('flex-12-of-12') %}
 {% endif %}
-<div{{ attributes.addClass('jumpstart-ui--one-column', settings.centered, settings.extra_classes) }}>
-    <div {{ region_attributes.main.addClass('main-region') }}>
+
+{# If max width has been set allow it to override the centered option. #}
+{% if settings.columns|render is not empty and settings.columns != "default" %}
+  {% if region_attributes.main is iterable %}
+    {% set main_attributes = main_attributes.removeClass('flex-12-of-12').addClass(settings.columns) %}
+    {% set attributes = attributes.addClass('centered-content') %}
+  {% endif %}
+{% endif %}
+
+<div{{ attributes }}>
+    <div {{ main_attributes }}>
       {{ content.main }}
     </div>
 </div>

--- a/tests/src/Kernel/Layout/OneColLayoutTest.php
+++ b/tests/src/Kernel/Layout/OneColLayoutTest.php
@@ -50,6 +50,22 @@ class OneColLayoutTest extends KernelTestBase {
   /**
    * Layout should render when values are passed..
    */
+  public function testOneColLayoutColumnProps() {
+    // Boot twig environment.
+    $twig =  \Drupal::service('twig');
+    $template = drupal_get_path('module', 'jumpstart_ui') . '/templates/layouts/one-column.html.twig';
+    $props = $this->getProps();
+    $props['columns'] = 'flex-6-of-12';
+    $this->setRawContent((string) twig_render_template($template, $props));
+    $this->assertText("Somebody once told me php unit is gonna rule me");
+    $this->assertContains("boy-is-this-a-neat-class", $this->getRawContent());
+    $this->assertContains("flex-6-of-12", $this->getRawContent());
+    $this->assertContains('jumpstart-ui--one-column', $this->getRawContent());
+  }
+
+  /**
+   * Layout should render when values are passed..
+   */
   public function testOneColLayoutNoProps() {
     // Boot twig environment.
     $twig =  \Drupal::service('twig');
@@ -89,6 +105,7 @@ class OneColLayoutTest extends KernelTestBase {
       'settings' => [
         'extra_classes' => "boy-is-this-a-neat-class",
         'centered' => 'centered-container',
+        'columns' => 'default'
       ],
       'attributes' => new Attribute(['class' => 'wrapper-test']),
     ];

--- a/tests/src/Kernel/Layout/OneColLayoutTest.php
+++ b/tests/src/Kernel/Layout/OneColLayoutTest.php
@@ -55,7 +55,7 @@ class OneColLayoutTest extends KernelTestBase {
     $twig =  \Drupal::service('twig');
     $template = drupal_get_path('module', 'jumpstart_ui') . '/templates/layouts/one-column.html.twig';
     $props = $this->getProps();
-    $props['columns'] = 'flex-6-of-12';
+    $props['settings']['columns'] = 'flex-6-of-12';
     $this->setRawContent((string) twig_render_template($template, $props));
     $this->assertText("Somebody once told me php unit is gonna rule me");
     $this->assertContains("boy-is-this-a-neat-class", $this->getRawContent());

--- a/tests/src/Unit/Layouts/JumpstartUiLayoutsTest.php
+++ b/tests/src/Unit/Layouts/JumpstartUiLayoutsTest.php
@@ -29,9 +29,10 @@ class JumpstartUiLayoutsTest extends UnitTestCase {
    * The form class should save the values appropriately.
    */
   public function testLayoutForm() {
-    $object = new JumpstartUiLayouts([], '', []);
+    $object = new JumpstartUiLayouts(['label' => ''], '', []);
     $this->assertArrayHasKey('extra_classes', $object->defaultConfiguration());
     $this->assertArrayHasKey('centered', $object->defaultConfiguration());
+    $this->assertArrayHasKey('columns', $object->defaultConfiguration());
 
     $form = [];
     $form_state = new FormState();
@@ -39,14 +40,20 @@ class JumpstartUiLayoutsTest extends UnitTestCase {
 
     $this->assertArrayHasKey('extra_classes', $form);
     $this->assertArrayHasKey('centered', $form);
+    $this->assertArrayHasKey('columns', $form);
+    $this->assertArrayHasKey('label', $form);
 
     $form_state->setValue('extra_classes', 'foo bar_baz');
     $form_state->setValue('centered', FALSE);
+    $form_state->setValue('columns', 'flex-6-of-12');
+    $form_state->setValue('label', 'Admin Label');
 
     $object->submitConfigurationForm($form, $form_state);
     $config = $object->getConfiguration();
 
     $this->assertEquals('foo bar-baz', $config['extra_classes']);
+    $this->assertEquals('flex-6-of-12', $config['columns']);
+    $this->assertEquals('Admin Label', $config['label']);
     $this->assertNull($config['centered']);
 
     $form_state->setValue('extra_classes', '@!:fooBar?');

--- a/tests/src/Unit/Layouts/JumpstartUiThreeColumnLayoutTest.php
+++ b/tests/src/Unit/Layouts/JumpstartUiThreeColumnLayoutTest.php
@@ -4,16 +4,16 @@ namespace Drupal\Tests\jumpstart_ui\Unit\Layouts;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Form\FormState;
-use Drupal\jumpstart_ui\Layouts\JumpstartUiTwoColumnLayout;
+use Drupal\jumpstart_ui\Layouts\JumpstartUiThreeColumnLayout;
 use Drupal\Tests\UnitTestCase;
 
 /**
- * Class JumpstartUiTwoColumnLayoutTest.
+ * Class JumpstartUiThreeColumnLayoutTest.
  *
  * @group jumpstart_ui
- * @coversDefaultClass \Drupal\jumpstart_ui\Layouts\JumpstartUiTwoColumnLayout
+ * @coversDefaultClass \Drupal\jumpstart_ui\Layouts\JumpstartUiThreeColumnLayout
  */
-class JumpstartUiTwoColumnLayoutTest extends UnitTestCase {
+class JumpstartUiThreeColumnLayoutTest extends UnitTestCase {
 
   /**
    * {@inheritDoc}
@@ -29,10 +29,9 @@ class JumpstartUiTwoColumnLayoutTest extends UnitTestCase {
    * The form class should save the values appropriately.
    */
   public function testLayoutForm() {
-    $object = new JumpstartUiTwoColumnLayout(['label' => ''], '', []);
+    $object = new JumpstartUiThreeColumnLayout(['label' => ''], '', []);
     $this->assertArrayHasKey('extra_classes', $object->defaultConfiguration());
     $this->assertArrayHasKey('centered', $object->defaultConfiguration());
-    $this->assertArrayHasKey('orientation', $object->defaultConfiguration());
 
     $form = [];
     $form_state = new FormState();
@@ -40,31 +39,27 @@ class JumpstartUiTwoColumnLayoutTest extends UnitTestCase {
 
     $this->assertArrayHasKey('extra_classes', $form);
     $this->assertArrayHasKey('centered', $form);
-    $this->assertArrayHasKey('orientation', $form);
     $this->assertArrayHasKey('label', $form);
 
     $form_state->setValue('extra_classes', 'foo bar_baz');
     $form_state->setValue('centered', FALSE);
-    $form_state->setValue('orientation', 'left');
     $form_state->setValue('label', 'Admin Label');
 
     $object->submitConfigurationForm($form, $form_state);
     $config = $object->getConfiguration();
 
     $this->assertEquals('foo bar-baz', $config['extra_classes']);
+    $this->assertEquals('Admin Label', $config['label']);
     $this->assertNull($config['centered']);
-    $this->assertEquals('left', $config['orientation']);
 
     $form_state->setValue('extra_classes', '@!:fooBar?');
     $form_state->setValue('centered', TRUE);
-    $form_state->setValue('orientation', 'equal');
 
     $object->submitConfigurationForm($form, $form_state);
     $config = $object->getConfiguration();
 
     $this->assertEquals('fooBar', $config['extra_classes']);
     $this->assertEquals('centered-container', $config['centered']);
-    $this->assertEquals('equal', $config['orientation']);
   }
 
 }


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Adds ability to set a max-width (in columns) for the one column layout
- Useful for theming single column pages
- Restores the admin label default option from layout builder

# Needed By (Date)
- The time stanford_news gets merged. 

# Urgency
- Medium

# Steps to Test

1. Check out this branch and clear all caches in a cardinalsites or lelandd8 soe install
2. Edit a basic page layout 
3. Add a new section and select the one column option
4. In the configuration form select a number of columns and save
5. Put something like a custom block or a field into the new section
6. Save the layout and view the rendered node
7. Validate that the section is sized correctly.

# Affected Projects or Products
- Stanford News

# Associated Issues and/or People
- 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
