### PR TITLE
Added a one column with an overlay layout

### DIFF
--- a/jumpstart_ui.layouts.yml
+++ b/jumpstart_ui.layouts.yml
@@ -15,6 +15,19 @@ defaults: &defaults
 jumpstart_ui_one_column:
   <<: *defaults
 
+jumpstart_ui_one_column_overlay:
+  <<: *defaults
+  label: Stanford One Column with Overlay
+  regions:
+    main:
+      label: Main
+    overlay:
+      label: Overlay
+  template: one-column-overlay
+  icon_map:
+    - [main]
+    - [overlay]
+
 # Two Column
 jumpstart_ui_two_column:
   <<: *defaults

--- a/jumpstart_ui.module
+++ b/jumpstart_ui.module
@@ -84,9 +84,8 @@ function jumpstart_ui_preprocess_pattern_localfooter(&$variables) {
  * Implements hook_preprocess_HOOK().
  */
 function jumpstart_ui_preprocess_layout(&$variables) {
-  $layout_builder_routes = ['layout_builder.defaults.node.view'];
   $current_route = \Drupal::routeMatch()->getRouteName();
-  if (in_array($current_route, $layout_builder_routes)) {
+  if (strpos($current_route, 'layout_builder.') === 0) {
     // Add a flag if the user is currently in layout builder. This allow the
     // template to make it easier for users to move blocks in layout builder.
     $variables['layout_builder_admin'] = TRUE;

--- a/jumpstart_ui.module
+++ b/jumpstart_ui.module
@@ -79,3 +79,16 @@ function jumpstart_ui_preprocess_pattern_localfooter(&$variables) {
     $variables['weblogin_url'] = $route->toString();
   }
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function jumpstart_ui_preprocess_layout(&$variables) {
+  $layout_builder_routes = ['layout_builder.defaults.node.view'];
+  $current_route = \Drupal::routeMatch()->getRouteName();
+  if (in_array($current_route, $layout_builder_routes)) {
+    // Add a flag if the user is currently in layout builder. This allow the
+    // template to make it easier for users to move blocks in layout builder.
+    $variables['layout_builder_admin'] = TRUE;
+  }
+}

--- a/templates/layouts/one-column-overlay.html.twig
+++ b/templates/layouts/one-column-overlay.html.twig
@@ -2,12 +2,23 @@
   {% set region_attributes_main = region_attributes.main.addClass('flex-12-of-12') %}
   {% set region_attributes = region_attributes|merge({'main': region_attributes_main}) %}
 {% endif %}
-<div{{ attributes.addClass('jumpstart-ui--one-column', settings.centered, settings.extra_classes) }}>
-  <div {{ region_attributes.main.addClass('main-region') }}>
-    {{ content.main }}
-  </div>
 
-  <div {{ region_attributes.overlay.addClass('overlay-region') }}>
-    {{ content.overlay }}
+{% if layout_builder_admin %}
+  <div{{ attributes.addClass('jumpstart-ui--one-column', settings.centered, settings.extra_classes) }}>
+    <div {{ region_attributes.main.addClass('main-region') }}>
+      <div>{{ 'Background Image'|t }}</div>
+      {{ content.main }}
+    </div>
+
+    <div {{ region_attributes.overlay.addClass('overlay-region') }}>
+      <div>{{ 'Overlaying Contents'|t }}</div>
+      {{ content.overlay }}
+    </div>
   </div>
-</div>
+{% else %}
+  {% set hero_body = content.overlay %}
+  {% set hero_image = content.main %}
+  {% include "@decanter/components/hero/hero.twig" %}
+{% endif %}
+
+

--- a/templates/layouts/one-column-overlay.html.twig
+++ b/templates/layouts/one-column-overlay.html.twig
@@ -1,0 +1,13 @@
+{% if 'centered-container' in settings.centered|render and region_attributes.main is iterable %}
+  {% set region_attributes_main = region_attributes.main.addClass('flex-12-of-12') %}
+  {% set region_attributes = region_attributes|merge({'main': region_attributes_main}) %}
+{% endif %}
+<div{{ attributes.addClass('jumpstart-ui--one-column', settings.centered, settings.extra_classes) }}>
+  <div {{ region_attributes.main.addClass('main-region') }}>
+    {{ content.main }}
+  </div>
+
+  <div {{ region_attributes.overlay.addClass('overlay-region') }}>
+    {{ content.overlay }}
+  </div>
+</div>

--- a/templates/layouts/one-column-overlay.html.twig
+++ b/templates/layouts/one-column-overlay.html.twig
@@ -20,5 +20,3 @@
   {% set hero_image = content.main %}
   {% include "@decanter/components/hero/hero.twig" %}
 {% endif %}
-
-

--- a/tests/src/Kernel/Layout/OneColOverlayLayoutTest.php
+++ b/tests/src/Kernel/Layout/OneColOverlayLayoutTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\Tests\jumpstart_ui\Kernel\Layout;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Class OneColLayoutOverlayTest.
+ *
+ * @group jumpstart_ui
+ */
+class OneColOverlayLayoutTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'system',
+    'jumpstart_ui',
+    'components',
+  ];
+
+  /**
+   * Layout should render when values are passed..
+   */
+  public function testOverlayLayout() {
+    $template = \Drupal::service('twig')->load('@jumpstart_ui/layouts/one-column-overlay.html.twig');
+    $rendering = $template->render([
+      'content' => [
+        'main' => '<img src="foo-bar.jpg"/>',
+        'overlay' => '<div>Overlay Text</div>',
+      ],
+    ]);
+
+    $this->assertContains('foo-bar.jpg', $rendering);
+    $this->assertContains('Overlay Text', $rendering);
+    $this->assertNotEmpty(preg_grep('/class="su-hero/', explode("\n", $rendering)));
+    $this->assertNotEmpty(preg_grep('/class="su-hero__media/', explode("\n", $rendering)));
+    $this->assertNotEmpty(preg_grep('/class="su-card/', explode("\n", $rendering)));
+    $this->assertNotEmpty(preg_grep('/class="su-card__contents/', explode("\n", $rendering)));
+    preg_match_all('/<\//', $rendering, $closing_tags);
+    $this->assertCount(4, $closing_tags[0]);
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added a layout that simulates a hero with text overlay functionality

# Need Review By (Date)
- soon

# Urgency
- medium-high

# Steps to Test
1. checkout this branch
1. clear cache
1. edit a basic page layout
1. add the "Stanford One Column with Overlay" layout as a section
1. put an image field/block in the top region and some text fields or stuff in the overlay region
1. see it rendered out after you save.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
