### PR TITLE
Add settings.extra_classes to one column with an overlay layout

### DIFF
--- a/templates/layouts/one-column-overlay.html.twig
+++ b/templates/layouts/one-column-overlay.html.twig
@@ -19,5 +19,6 @@
   {% set hero_body = content.overlay %}
   {% set hero_image = content.main %}
   {% set modifier_class = settings.extra_classes %}
+  {% set attributes = attributes|without('class') %}
   {% include "@decanter/components/hero/hero.twig" %}
 {% endif %}

--- a/templates/layouts/one-column-overlay.html.twig
+++ b/templates/layouts/one-column-overlay.html.twig
@@ -18,5 +18,6 @@
 {% else %}
   {% set hero_body = content.overlay %}
   {% set hero_image = content.main %}
+  {% set modifier_class = settings.extra_classes %}
   {% include "@decanter/components/hero/hero.twig" %}
 {% endif %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added settings.extra_classes to one column with an overlay layout

# Needed By (Date)
- soon

# Urgency
- medium

# Steps to Test
1. Checkout this branch
2. Clear cache
3. Edit basic page layout
4. Add section with One Column with an Overlay layout
5. Add extra class
6. Add/create banner block and text block
7. View page and inspect to see that extra class is being applied

# Affected Projects or Products
- Cardinal Service Development

# Associated Issues and/or People
- [CSD-15](https://stanfordits.atlassian.net/browse/CSD-15)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
