### PR TITLE
D8CORE-1866 Convert special characters for the banner link pattern

### DIFF
--- a/templates/components/hero/hero.html.twig
+++ b/templates/components/hero/hero.html.twig
@@ -61,7 +61,7 @@
 {% set attributes = attributes|without('class') %}
 
 {% if hero_link is empty and hero_button_link|render|striptags('<drupal-render-placeholder>') is not empty %}
-  {% set hero_link = hero_button_link %}
+  {% set hero_link = hero_button_link|render|striptags('<drupal-render-placeholder>')|convert_encoding('UTF-8', 'HTML-ENTITIES') %}
 {% endif %}
 
 {#


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Convert special characters in the link field.

# Need Review By (Date)
- 6/26

# Urgency
- medium

# Steps to Test
1. Checkout this branch
1. Enter a url in the banner link field with some special characters like `http://stanford.edu/?foo=bar&bar=foo`
1. after you save the banner, validate the url is still in tact like you entered it.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
