### PR TITLE
D8CORE-2047:  make organization not look like a heading.

### DIFF
--- a/dist/css/local-footer.css
+++ b/dist/css/local-footer.css
@@ -1,1 +1,1 @@
-.su-local-footer__address .organization{font-weight:700}
+.su-local-footer__address .organization{font-weight:600}

--- a/lib/scss/components/local-footer.component.scss
+++ b/lib/scss/components/local-footer.component.scss
@@ -4,6 +4,6 @@
 
 .su-local-footer__address {
   .organization {
-    font-weight: $su-font-bold;
+    font-weight: $su-font-semi-bold;
   }
 }


### PR DESCRIPTION


# READY FOR REVIEW

# Summary
It was hard to distinguish the organization name from an actual heading. This reduces the font weight to make it look less like a heading.

# Needed By (Date)
Soon

# Urgency
Not urgent

# Steps to Test

1. Pull this branch
1. Clear cache
1. Verify the font-weight is 600

# Affected Projects or Products
d8core

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/D8CORE-2047
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
