### PR TITLE
D8CORE-1726: making sure the h2 does not show as empty tags

### DIFF
--- a/templates/components/card/card.html.twig
+++ b/templates/components/card/card.html.twig
@@ -3,6 +3,7 @@
  #}
 {%- set card_cta_label = card_cta_label|render|striptags('<drupal-render-placeholder>')|trim|convert_encoding('UTF-8', 'HTML-ENTITIES') -%}
 {%- set card_link = card_link|render|striptags('<drupal-render-placeholder>') -%}
+{% set card_headline = card_headline|render|striptags('<drupal-render-placeholder>')|trim|convert_encoding('UTF-8', 'HTML-ENTITIES') %}
 
 {#
   You are not allowed to have both action and button at the same time so remove the button


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Making sure the h2 markup doesn't appear when it is empty.

# Needed By (Date)
- 8/6

# Urgency
- Urgent

# Steps to Test

1. Add a card to your local build without a headline. See there is an empty h2.
2. Pull in this change.
3. Clear cache.
4. See there is no more empty h2.

# Affected Projects or Products
- SOE 
- HTML validation
- Core

# Associated Issues and/or People
- D8CORE-1726
- @cjwest 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)

# Note:
Added @pookmish  since he showed me how to fix.
