### PR TITLE
D8CORE 2499

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "drupal-custom-module",
   "homepage": "https://github.com/SU-SWS/jumpstart_ui",
   "authors": [],
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "minimum-stability": "dev",
   "repositories": [
     {


### PR DESCRIPTION
- D8CORE-1726: making sure the h2 does not show as empty tags (#66)
- 8.1.9
- Back to dev
- Fix the card template with empty headlines (#68)
- Back to dev
- D8CORE-2499 Updated composer license
