### PR TITLE
D8CORE-2534: URL encode link in card component.

### DIFF
--- a/templates/components/card/card.html.twig
+++ b/templates/components/card/card.html.twig
@@ -2,7 +2,7 @@
  # Sanitize some of the Drupalness in the picky fields.
  #}
 {%- set card_cta_label = card_cta_label|render|striptags('<drupal-render-placeholder>')|trim|convert_encoding('UTF-8', 'HTML-ENTITIES') -%}
-{%- set card_link = card_link|render|striptags('<drupal-render-placeholder>') -%}
+{%- set card_link = card_link|render|striptags('<drupal-render-placeholder>')|trim|convert_encoding('UTF-8', 'HTML-ENTITIES') -%}
 {% if card_headline|render|striptags('<drupal-render-placeholder>')|trim is empty %}
   {% set card_headline = null %}
 {% endif %}

--- a/templates/components/card/card.ui_patterns.yml
+++ b/templates/components/card/card.ui_patterns.yml
@@ -54,7 +54,7 @@ card:
       type: text
       label: "Link URL"
       description: "A plain text string of just the URL"
-      preview: "https://stanford.edu"
+      preview: "https://stanford.edu/?a=b&c=d"
     card_cta_attributes:
       type: text
       label: "CTA Attributes"

--- a/tests/codeception/acceptance/ComponentsCest.php
+++ b/tests/codeception/acceptance/ComponentsCest.php
@@ -87,7 +87,7 @@ class ComponentsCest {
     $I->canSeeNumberOfElements('#content .su-card--video', 1);
     $I->canSeeNumberOfElements('#content .su-card--embed', 1);
 
-    $href = $I->grabAttributeFrom('.su-card__link:first', 'href');
+    $href = $I->grabAttributeFrom('.su-card__link', 'href');
     $I->assertEquals($href, "https://stanford.edu/?a=b&c=d");
   }
 

--- a/tests/codeception/acceptance/ComponentsCest.php
+++ b/tests/codeception/acceptance/ComponentsCest.php
@@ -86,6 +86,9 @@ class ComponentsCest {
     $I->canSeeNumberOfElements('#content .su-card--icon', 1);
     $I->canSeeNumberOfElements('#content .su-card--video', 1);
     $I->canSeeNumberOfElements('#content .su-card--embed', 1);
+
+    $href = $I->grabAttributeFrom('.su-card__link:first', 'href');
+    $I->assertEquals($href, "https://stanford.edu/?a=b&c=d");
   }
 
   /**


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Allows for special characters in the URL field

# Needed By (Date)
- Sept 2nd

# Urgency
- Med/Low

# Steps to Test

1. Look at code
2. Go find something to eat in the fridge
3. Come back and think about looking at code
4. Procrastinate
5. Check out this branch in a working build
6. Clear caches
7. Visit `/patterns`
8. Inspect link in card output

# Affected Projects or Products
- D8CORE
- SOE

# Associated Issues and/or People
- D8CORE-2534
- @rmundstock 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
