### PR TITLE
D8CORE-2498 D8CORE-2496 Fix link urls in the local footer

### DIFF
--- a/templates/macros/field-links-to-list.twig
+++ b/templates/macros/field-links-to-list.twig
@@ -3,15 +3,16 @@
     <ul {{ with_url }}>
   {% endif %}
 
-  {# find the field name and start looping through the items. #}
-  {% set field_keys = field|keys %}
-  {% set field_info = field[field_keys[0]] %}
-  {% set field_items = field_info["#items"] %}
-
-  {% for item in field_items %}
-    <li {{ list_attributes }}>
-      <a href="{{ item.uri }}" {{ item.options }}>{{ item.title }}</a>
-    </li>
+  {# Loop through each of the fields that are available. #}
+  {% for field_key in field|keys %}
+    {% for delta, item in field[field_key] %}
+      {# If the key of the field is an integer, we can use that. #}
+      {% if delta matches '/^\\d+$/' %}
+        <li {{ list_attributes }}>
+          {{ item }}
+        </li>
+      {% endif %}
+    {% endfor %}
   {% endfor %}
 
   {% if with_url is not empty %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Modified the template to render out entity urls instead of `entity:node/12`
- see https://github.com/SU-SWS/stanford_profile/pull/300 for tests

# Need Review By (Date)
- 10/1

# Urgency
- medium

# Steps to Test
1. checkout this branch
1. edit the local footer config page and put in links to other nodes
1. save and verify the urls in the footer are formatted correctly

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
