### PR TITLE
D8CORE-2529: Fixing the media with link or no link.

### DIFF
--- a/templates/components/media/media.html.twig
+++ b/templates/components/media/media.html.twig
@@ -1,5 +1,5 @@
 {%- if media_img_src is empty and
-  media_custom|render_clean('<img> <picture> <iframe>') is empty -%}
+  media_custom|render_clean('<img> <picture>') is empty -%}
   {%- set media_link = false -%}
 {% else %}
   {%- set media_link = media_link|render_clean -%}

--- a/templates/components/media/media.html.twig
+++ b/templates/components/media/media.html.twig
@@ -1,4 +1,17 @@
-{%- set media_link = media_link|render_clean -%}
+{#What I want:#}
+{#if all the medias are empty:#}
+{#{%- if (media_img_src is empty) or (media_audio_src is empty) or (media_audio_src is empty) -%}#}
+{#no link:#}
+{#{%- set media_link = false -%}#}
+{#if one is entered: {% else %}#}
+{#{%- set media_link = media_link|render_clean -%}#}
+
+{%- if (media_img_src is empty) -%}
+  {%- set media_link = false -%}
+{% else %}
+  {%- set media_link = media_link|render_clean -%}
+{% endif %}
+
 {% if attributes is not empty %}
   {% set attributes = attributes.removeClass('su-media') %}
 {% else %}

--- a/templates/components/media/media.html.twig
+++ b/templates/components/media/media.html.twig
@@ -1,12 +1,5 @@
-{#What I want:#}
-{#if all the medias are empty:#}
-{#{%- if (media_img_src is empty) or (media_audio_src is empty) or (media_audio_src is empty) -%}#}
-{#no link:#}
-{#{%- set media_link = false -%}#}
-{#if one is entered: {% else %}#}
-{#{%- set media_link = media_link|render_clean -%}#}
-
-{%- if (media_img_src is empty) -%}
+{%- if media_img_src is empty and
+  media_custom|render_clean('<img> <picture> <iframe>') is empty -%}
   {%- set media_link = false -%}
 {% else %}
   {%- set media_link = media_link|render_clean -%}


### PR DESCRIPTION
# READY FOR REVIEW
HELP. Can someone comment why this doesn't work? I added the things I'd like to happen but it just isn't working for me. Could it be a caching like @pookmish and I discussed? I'm at a loss.

Edit: I spoke to @pookmish and he showed me a fix that worked well. I have that up so this is ready for review.

# Summary
- I want no link to appear if the client doesn't add an image
- I want to be able to have multiple types on a page. Some might have an image and others won't with a mixture of those with or without a link.

# Needed By (Date)
- Nice to have for 1.5.1. I think that ship has sailed.

# Urgency
- It is a known and documented issue. It is resolvable by documentation.

# Steps to Test

1. Pull in this code
2. Create Media with Caption. One with image and link. One with just a link.
3. Notice there's no link on both. 

# Affected Projects or Products
- Any project using the paragraph

# Associated Issues and/or People
- D8CORE-2529

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
