### PR TITLE
D8CORE-4362 Remove empty <ul> tag in local footer template

### DIFF
--- a/templates/components/local-footer/local-footer.html.twig
+++ b/templates/components/local-footer/local-footer.html.twig
@@ -22,6 +22,19 @@
 {%- set primary_links_header = primary_links_header|render_clean -%}
 {%- set secondary_links_header = secondary_links_header|render_clean -%}
 
+{% if action_links|render_clean('<ul> <li> <a>') is empty %}
+  {% set action_links = null %}
+{% endif %}
+{% if social_links|render_clean('<ul> <li> <a>') is empty %}
+  {% set social_links = null %}
+{% endif %}
+{% if primary_links|render_clean('<ul> <li> <a>') is empty %}
+  {% set primary_links = null %}
+{% endif %}
+{% if secondary_links|render_clean('<ul> <li> <a>') is empty %}
+  {% set secondary_links = null %}
+{% endif %}
+
 {# Ensure attributes is not empty and remove extra css classes if it does #}
 {% if attributes is empty %}
   {% set attributes = create_attribute() %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Prevent empty `<ul>` elements in local footer

# Need Review By (Date)
- 7/8

# Urgency
- High

# Steps to Test
1. Checkout this branch
2. edit the local footer and remove all links from the "Primary" and "Secondary" links
3. save and ensure there are no empty `<ul>` tags in the local footer.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
