### PR TITLE
D8CORE-4786 Use the line 1 for the image alt

### DIFF
--- a/templates/components/local-footer/local-footer.html.twig
+++ b/templates/components/local-footer/local-footer.html.twig
@@ -73,6 +73,7 @@
   {% if use_logo == "0" %}
     {% embed "@decanter/components/lockup/lockup.twig" with lockup_options %}
 
+      {% set image_alt = line1 %}
       {# if the option was set to logo only. Remove the lines. #}
       {% if 'su-lockup--option-none' in lockup_option %}
         {% set line1 = '' %}
@@ -85,7 +86,7 @@
       {# Override cell 1 with the logo. #}
       {% block cell1 %}
         <div class="su-lockup__logo-wrapper">
-          <img src="{{ site_logo }}" alt="{{ line1 }}" class="su-lockup__custom-logo" />
+          <img src="{{ site_logo }}" alt="{{ image_alt }}" class="su-lockup__custom-logo" />
           {% if line4 is not empty %}
             <span class="su-lockup__line4">{{ line4 }}</span>
           {% endif %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- When using "Logo Only" option in the local footer, ensure the line1 is still used for the logo alt text.

# Need Review By (Date)
- 10/10

# Urgency
- low

# Steps to Test
1. checkout this branch.
2. go to `/admin/config/system/local-footer` and upload an image and choose "Logo Only" for the "Local Lockup" settings.
3. view the home page
4. verify the logo in the local footer has an alt text

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
