### PR TITLE
Update for Drupal 10 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "drupal/core": "^8.8 || ^9.0",
+    "drupal/core": "^8.8 || ^9.0 || ^10.0",
     "drupal/components": "^2.0",
     "drupal/ds": "^3.3",
     "drupal/ui_patterns": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   ],
   "require": {
     "drupal/core": "^8.8 || ^9.0 || ^10.0",
-    "drupal/components": "^2.0",
+    "drupal/components": "^2.0 || ^3.0",
     "drupal/ds": "^3.3",
     "drupal/ui_patterns": "^1.0"
   },

--- a/dist/templates/decanter/components/secondary-nav/secondary-nav.twig
+++ b/dist/templates/decanter/components/secondary-nav/secondary-nav.twig
@@ -15,12 +15,12 @@
 +#}
 {% import "@decanter/utilities/macros/menu-loop.twig" as menus %}
 <nav {{ attributes }} class="su-secondary-nav no-js {{ modifier_class }}" aria-label="{{ aria_label|default('secondary menu') }}">
-  {% spaceless %}
+  {% apply spaceless %}
   {% if list_items is iterable %}
     {{ menus.nav_menu(list_items, 1, 'su-secondary-nav') }}
   {% else %}
     {# If custom markup is provided, emit it as is #}
     {{ list_items }}
   {% endif %}
-  {% endspaceless %}
+  {% endapply %}
 </nav>

--- a/dist/templates/decanter/utilities/macros/link-list.twig
+++ b/dist/templates/decanter/utilities/macros/link-list.twig
@@ -4,7 +4,7 @@
  */
 #}
 {% macro link_list(items) %}
-  {% spaceless %}
+  {% apply spaceless %}
   {% for item in items %}
 
     {# Define the attributes vars fresh on each loop #}
@@ -42,5 +42,5 @@
       <a href="{{ item.href }}" {{ link_attributes }}>{{ item.text }}</a>
     </li>
   {% endfor %}
-  {% endspaceless %}
+  {% endapply %}
 {% endmacro %}

--- a/dist/templates/decanter/utilities/macros/menu-loop.twig
+++ b/dist/templates/decanter/utilities/macros/menu-loop.twig
@@ -6,7 +6,7 @@
 {% macro nav_menu(items, menu_level, class_prefix) %}
   {% import _self as menus %}
   <ul class="{{ class_prefix }}__menu-lv{{ menu_level }} {{ class_prefix }}__menu">
-  {% spaceless %}
+  {% apply spaceless %}
   {% for item in items %}
     {% set is_parent = item.children is empty ? false : true %}
     {% set list_classes = class_prefix ~ "__item " %}
@@ -36,6 +36,6 @@
       {% endif %}
     </li>
   {% endfor %}
-  {% endspaceless %}
+  {% endapply %}
   </ul>
 {% endmacro %}

--- a/jumpstart_ui.info.yml
+++ b/jumpstart_ui.info.yml
@@ -3,7 +3,7 @@ type: module
 description: 'Provides UI Tools for Jumpstart Projects'
 package: Stanford
 version: 8.x-1.24-dev
-core_version_requirement: ^8.8 || ^9
+core_version_requirement: ^8.8 || ^9 || ^10
 dependencies:
   - components:components
   - drupal:block


### PR DESCRIPTION
# READY FOR REVIEW
- One aspect for the module's maintainers to consider is whether to deprecate support for Drupal ^8.8. This PR does not remove that support.

# Summary
- In preparing the fsh.stanford.edu site for Drupal 10 I saw that the contrib module [upgrade_status](https://drupal.org/project/upgrade_status) recommended changes to the info.yml and composer.json files to indicate that the module is compatible with Drupal 10. The upgrade_status module recommended no other changes; I have not independently reviewed the module's code base for further Drupal 10 incompatibilities.

# Review By 10/1/2023
- Drupal 9 reaches end of life in November of 2023. Sites that use this module will need to patch it in it current state in order to use it in sites that are upgraded to Drupal 10.

# Criticality
- Changes to this module's .info.yml and composer.json files are critical for sites that use the module and are upgrading from Drupal 9 to Drupal 10.

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. In a Drupal 9 site that uses this module, patch the module using this pull request's diff
2. Install and enable the upgrade_status module
3. At /admin/reports/upgrade-status scan the jumpstart_ui module, then observe that it does not report problems associated with the .info.yml or composer.json files.

### Site Configuration Sync

- No config sync implications

## Front End Validation
- There are no front end implications to this PR.

## Backend / Functional Validation
### Code
- [yes] Are the naming conventions following our standards?
- [yes] Does the code have sufficient inline comments?
- [no] Is there anything in this code that would be hidden or hard to discover through the UI?
- [no] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [no] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [n/a] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [y] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?
> This pull request does not remove support for Drupal ^8.8. Drupal 8 is no longer supported. 

## General
- [no] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [yes] Is the approach to the problem appropriate?

# Affected Projects or Products
- The fsh.stanford.edu project uses this module.

# Associated Issues and/or People
- Steven Sangervasi

